### PR TITLE
binarized unsupervised output with 'binarized' boolean API parameter

### DIFF
--- a/src/apidata.cc
+++ b/src/apidata.cc
@@ -60,6 +60,12 @@ namespace dd
     return vout();
   }
   
+  vout visitor_vad::process(const std::vector<bool> &vd)
+  {
+    (void)vd;
+    return vout();
+  }
+
   vout visitor_vad::process(const std::vector<std::string> &vs)
   {
     (void)vs;
@@ -114,6 +120,15 @@ namespace dd
 		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
 		      {
 			vd.push_back(jarr[i].GetInt());
+		      }
+		    add(cit->name.GetString(),vd);
+		  }
+		else if (jarr[0].IsBool())
+		  {
+		    std::vector<bool> vd;
+		    for (rapidjson::SizeType i=0;i<jarr.Size();i++)
+		      {
+			vd.push_back(jarr[i].GetBool());
 		      }
 		    add(cit->name.GetString(),vd);
 		  }

--- a/src/apidata.h
+++ b/src/apidata.h
@@ -39,7 +39,7 @@ namespace dd
 
   // recursive variant container, see utils/variant.hpp and utils/recursive_wrapper.hpp
   typedef mapbox::util::variant<std::string,double,int,bool,
-    std::vector<std::string>,std::vector<double>,std::vector<int>,
+    std::vector<std::string>,std::vector<double>,std::vector<int>,std::vector<bool>,
     mapbox::util::recursive_wrapper<std::vector<APIData>>> ad_variant_type;
 
   /**
@@ -83,6 +83,7 @@ namespace dd
     vout process(const bool &b);
     vout process(const std::vector<double> &vd);
     vout process(const std::vector<int> &vd);
+    vout process(const std::vector<bool> &vd);
     vout process(const std::vector<std::string> &vs);
     vout process(const std::vector<APIData> &vad);
     
@@ -329,6 +330,17 @@ namespace dd
       else _jv->AddMember(_jvkey,jarr,_jd->GetAllocator());
     }
     void process(const std::vector<int> &vd)
+    {
+      JVal jarr(rapidjson::kArrayType);
+      for (size_t i=0;i<vd.size();i++)
+	{
+	  jarr.PushBack(JVal(vd.at(i)),_jd->GetAllocator());
+	}
+      if (!_jv)
+	_jd->AddMember(_jvkey,jarr,_jd->GetAllocator());
+      else _jv->AddMember(_jvkey,jarr,_jd->GetAllocator());
+    }
+    void process(const std::vector<bool> &vd)
     {
       JVal jarr(rapidjson::kArrayType);
       for (size_t i=0;i<vd.size();i++)

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -22,8 +22,6 @@
 #ifndef SUPERVISEDOUTPUTCONNECTOR_H
 #define SUPERVISEDOUTPUTCONNECTOR_H
 
-//#include "outputconnectorstrategy.h"
-
 namespace dd
 {
 

--- a/src/unsupervisedoutputconnector.h
+++ b/src/unsupervisedoutputconnector.h
@@ -40,8 +40,24 @@ namespace dd
 	_vals.at(i) = _vals.at(i) <= 0.0 ? 0.0 : 1.0;
     }
     
+    void bool_binarized()
+    {
+      for (size_t i=0;i<_vals.size();i++)
+	_bvals.push_back(_vals.at(i) <= 0.0 ? false : true);
+      _vals.clear();
+    }
+
+    void string_binarized()
+    {
+       for (size_t i=0;i<_vals.size();i++)
+	_str += _vals.at(i) <= 0.0 ? "0" : "1";
+      _vals.clear();
+    }
+
     std::string _uri;
     std::vector<double> _vals;
+    std::vector<bool> _bvals;
+    std::string _str;
   };
   
   /**
@@ -67,6 +83,10 @@ namespace dd
       APIData ad_out = ad.getobj("parameters").getobj("output");
       if (ad_out.has("binarized"))
 	_binarized = ad_out.get("binarized").get<bool>();
+      else if (ad_out.has("bool_binarized"))
+	_bool_binarized = ad_out.get("bool_binarized").get<bool>();
+      else if (ad_out.has("string_binarized"))
+	_string_binarized = ad_out.get("string_binarized").get<bool>();
     }
     
     void add_results(const std::vector<APIData> &vrad)
@@ -89,11 +109,29 @@ namespace dd
     {
       if (ad_in.has("binarized"))
 	_binarized = ad_in.get("binarized").get<bool>();
+      else if (ad_in.has("bool_binarized"))
+	_bool_binarized = ad_in.get("bool_binarized").get<bool>();
+      else if (ad_in.has("string_binarized"))
+	_string_binarized = ad_in.get("string_binarized").get<bool>();
       if (_binarized)
 	{
 	  for (size_t i=0;i<_vvres.size();i++)
 	    {
 	      _vvres.at(i).binarized();
+	    }
+	}
+      else if (_bool_binarized)
+	{
+	  for (size_t i=0;i<_vvres.size();i++)
+	    {
+	      _vvres.at(i).bool_binarized();
+	    }
+	}
+      else if (_string_binarized)
+	{
+	  for (size_t i=0;i<_vvres.size();i++)
+	    {
+	      _vvres.at(i).string_binarized();
 	    }
 	}
       to_ad(ad_out);
@@ -106,7 +144,11 @@ namespace dd
 	{
 	  APIData adpred;
 	  adpred.add("uri",_vvres.at(i)._uri);
-	  adpred.add("vals",_vvres.at(i)._vals);
+	  if (_bool_binarized)
+	    adpred.add("vals",_vvres.at(i)._bvals);
+	  else if (_string_binarized)
+	    adpred.add("vals",_vvres.at(i)._str);
+	  else adpred.add("vals",_vvres.at(i)._vals);
 	  if (i == _vvres.size()-1)
 	    adpred.add("last",true);
 	  vpred.push_back(adpred);
@@ -117,6 +159,8 @@ namespace dd
     std::unordered_map<std::string,int> _vres; /**< batch of results index, per uri. */
     std::vector<unsup_result> _vvres; /**< ordered results, per uri. */
     bool _binarized = false; /**< binary representation of output values. */
+    bool _bool_binarized = false; /**< boolean binary representation of output values. */
+    bool _string_binarized = false; /**< boolean string as binary representation of output values. */
   };
 
 }

--- a/src/unsupervisedoutputconnector.h
+++ b/src/unsupervisedoutputconnector.h
@@ -34,6 +34,12 @@ namespace dd
 
     ~unsup_result() {}
 
+    void binarized()
+    {
+      for (size_t i=0;i<_vals.size();i++)
+	_vals.at(i) = _vals.at(i) <= 0.0 ? 0.0 : 1.0;
+    }
+    
     std::string _uri;
     std::vector<double> _vals;
   };
@@ -58,12 +64,13 @@ namespace dd
 
     void init(const APIData &ad)
     {
-      //TODO: output connector parameters, if any
+      APIData ad_out = ad.getobj("parameters").getobj("output");
+      if (ad_out.has("binarized"))
+	_binarized = ad_out.get("binarized").get<bool>();
     }
-
+    
     void add_results(const std::vector<APIData> &vrad)
     {
-      //TODO
       std::unordered_map<std::string,int>::iterator hit;
       for (APIData ad: vrad)
 	{
@@ -80,7 +87,15 @@ namespace dd
 
     void finalize(const APIData &ad_in, APIData &ad_out)
     {
-      //TODO
+      if (ad_in.has("binarized"))
+	_binarized = ad_in.get("binarized").get<bool>();
+      if (_binarized)
+	{
+	  for (size_t i=0;i<_vvres.size();i++)
+	    {
+	      _vvres.at(i).binarized();
+	    }
+	}
       to_ad(ad_out);
     }
 
@@ -101,6 +116,7 @@ namespace dd
     
     std::unordered_map<std::string,int> _vres; /**< batch of results index, per uri. */
     std::vector<unsup_result> _vvres; /**< ordered results, per uri. */
+    bool _binarized = false; /**< binary representation of output values. */
   };
 
 }


### PR DESCRIPTION
This is the binarized output for #56. It allows creating binary hash codes out of deep neural net layer weights. 

This PR paves the way toward straightforward image similarity search and other related applications.