### PR TITLE
Support for labeled data on POST /predict call

### DIFF
--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -64,6 +64,7 @@ namespace dd
     std::vector<caffe::Datum> _dv_test; /**< test input datum vector, when applicable in training mode */
     std::vector<std::string> _ids; /**< input ids (e.g. image ids) */
     bool _flat1dconv = false; /**< whether a 1D convolution model. */
+    bool _has_mean_file = false; /**< image model mean.binaryproto. */
   };
 
   /**
@@ -124,6 +125,8 @@ namespace dd
       if (!_train)
 	{
 	  _model_repo = ad.get("model_repo").get<std::string>();
+	  if (ad.has("has_mean_file"))
+	    _has_mean_file = ad.get("has_mean_file").get<bool>();
 	  try
 	    {
 	      ImgInputFileConn::transform(ad);
@@ -134,7 +137,7 @@ namespace dd
 	    }
 	  float *mean = nullptr;
 	  std::string meanfullname = _model_repo + "/" + _meanfname;
-	  if (_data_mean.count() == 0 && fileops::file_exists(meanfullname))
+	  if (_data_mean.count() == 0 && _has_mean_file)//fileops::file_exists(meanfullname)) //TODO: replace with flag for inputconnector instance, since it is not due to change during service life, nor is it allowed
 	    {
 	      caffe::BlobProto blob_proto;
 	      caffe::ReadProtoFromBinaryFile(meanfullname.c_str(),&blob_proto);

--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -137,7 +137,7 @@ namespace dd
 	    }
 	  float *mean = nullptr;
 	  std::string meanfullname = _model_repo + "/" + _meanfname;
-	  if (_data_mean.count() == 0 && _has_mean_file)//fileops::file_exists(meanfullname)) //TODO: replace with flag for inputconnector instance, since it is not due to change during service life, nor is it allowed
+	  if (_data_mean.count() == 0 && _has_mean_file)
 	    {
 	      caffe::BlobProto blob_proto;
 	      caffe::ReadProtoFromBinaryFile(meanfullname.c_str(),&blob_proto);

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1717,8 +1717,13 @@ namespace dd
 	      test_batch_size = ad_net.get("test_batch_size").get<int>();
 	  }
 	
-	bool has_mean_file = false;
+	bool has_mean_file = false; //TODO
 	test(_net,ad,inputc,test_batch_size,has_mean_file,out);
+	APIData out_meas = out.getobj("measure");
+	out_meas.erase("train_loss");
+	out_meas.erase("iteration");
+	std::vector<APIData> vad = {out_meas};
+	out.add("measure",vad);
 	return 0;
       }
     

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1695,15 +1695,7 @@ namespace dd
       }
 
     TInputConnectorStrategy inputc(this->_inputc);
-    int batch_size = inputc.test_batch_size();
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
-    if (ad_mllib.has("net"))
-      {
-	APIData ad_net = ad_mllib.getobj("net");
-	if (ad_net.has("test_batch_size"))
-	  batch_size = ad_net.get("test_batch_size").get<int>();
-      }
-    
     APIData ad_output = ad.getobj("parameters").getobj("output");
     if (ad_output.has("measure"))
       {
@@ -1717,6 +1709,14 @@ namespace dd
 	catch (std::exception &e)
 	  {
 	    throw;
+	  }
+
+	int batch_size = inputc.test_batch_size();
+	if (ad_mllib.has("net"))
+	  {
+	    APIData ad_net = ad_mllib.getobj("net");
+	    if (ad_net.has("test_batch_size"))
+	  batch_size = ad_net.get("test_batch_size").get<int>();
 	  }
 
 	bool has_mean_file = this->_mlmodel._has_mean_file;
@@ -1770,7 +1770,13 @@ namespace dd
       {
 	throw;
       }
-
+    int batch_size = inputc.test_batch_size();
+    if (ad_mllib.has("net"))
+      {
+	APIData ad_net = ad_mllib.getobj("net");
+	if (ad_net.has("test_batch_size"))
+	  batch_size = ad_net.get("test_batch_size").get<int>();
+      }
     try
       {
 	boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->set_batch_size(batch_size);

--- a/src/caffemodel.cc
+++ b/src/caffemodel.cc
@@ -57,6 +57,7 @@ namespace dd
     static std::string sstate = ".solverstate";
     static std::string corresp = "corresp";
     static std::string solver = "solver";
+    static std::string meanf = "mean.binaryproto";
     this->_repo = repo;
     std::unordered_set<std::string> lfiles;
     int e = fileops::list_directory(repo,true,false,lfiles);
@@ -70,7 +71,11 @@ namespace dd
     auto hit = lfiles.begin();
     while(hit!=lfiles.end())
       {
-	if ((*hit).find(sstate)!=std::string::npos)
+	if ((*hit) == meanf)
+	  {
+	    _has_mean_file = true;
+	  }
+	else if ((*hit).find(sstate)!=std::string::npos)
 	  {
 	    // stat file to pick the latest one
 	    long int st = fileops::file_last_modif((*hit));

--- a/src/caffemodel.h
+++ b/src/caffemodel.h
@@ -57,6 +57,7 @@ namespace dd
     std::string _solver; /**< solver description file, included here as part of the model, very specific to Caffe. */
     std::string _sstate; /**< current solver state, useful for resuming training. */
     std::string _model_template; /**< model template name, if any. */
+    bool _has_mean_file = false; /**< whether a mean.binaryproto file is available, for image models only. */
   };
   
 }

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -124,12 +124,61 @@ namespace dd
 
     int read_dir(const std::string &dir)
     {
-      throw InputConnectorBadParamException("uri " + dir + " is a directory, requires an image file");
+      //throw InputConnectorBadParamException("uri " + dir + " is a directory, requires an image file");
+      
+      // list directories in dir
+      std::unordered_set<std::string> subdirs;
+      if (fileops::list_directory(dir,false,true,subdirs))
+	throw InputConnectorBadParamException("failed reading text subdirectories in data directory " + dir);
+      std::cerr << "list subdirs size=" << subdirs.size() << std::endl;
+
+      // list files and classes
+      std::vector<std::pair<std::string,int>> lfiles; // labeled files
+      std::unordered_map<int,std::string> hcorresp; // correspondence class number / class name
+      if (!subdirs.empty())
+	{
+	  int cl = 0;
+	  auto uit = subdirs.begin();
+	  while(uit!=subdirs.end())
+	    {
+	      std::unordered_set<std::string> subdir_files;
+	      if (fileops::list_directory((*uit),true,false,subdir_files))
+		throw InputConnectorBadParamException("failed reading image data sub-directory " + (*uit));
+	      auto fit = subdir_files.begin();
+	      while(fit!=subdir_files.end()) // XXX: re-iterating the file is not optimal
+		{
+		  lfiles.push_back(std::pair<std::string,int>((*fit),cl));
+		  ++fit;
+		}
+	      ++cl;
+	      ++uit;
+	    }
+	}
+      else
+	{
+	  std::unordered_set<std::string> test_files;
+	  fileops::list_directory(dir,true,false,test_files);
+	  auto fit = test_files.begin();
+	  while(fit!=test_files.end())
+	    {
+	      lfiles.push_back(std::pair<std::string,int>((*fit),-1)); // -1 for no class
+	      ++fit;
+	    }
+	}
+      
+      // read images
+      for (std::pair<std::string,int> &p: lfiles)
+	{
+	  _img = cv::imread(p.first,_bw ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR);
+	  if (p.second >= 0)
+	    _label = p.second;
+	}
     }
     
-    cv::Mat _img;      
+    cv::Mat _img;
     bool _bw = false;
     bool _b64 = false;
+    int _label = -1;
   };
   
   class ImgInputFileConn : public InputConnectorStrategy
@@ -228,6 +277,8 @@ namespace dd
 #pragma omp critical
 	  {
 	    _images.push_back(image);
+	    if (dimg._ctype._label >= 0)
+	      _test_labels.push_back(dimg._ctype._label);
 	    if (!dimg._ctype._b64)
 	      uris.push_back(u);
 	    else uris.push_back(std::to_string(img_count));
@@ -278,6 +329,7 @@ namespace dd
     // data
     std::vector<cv::Mat> _images;
     std::vector<cv::Mat> _test_images;
+    std::vector<int> _test_labels;
     
     // image parameters
     int _width = 227;

--- a/src/imginputfileconn.h
+++ b/src/imginputfileconn.h
@@ -173,6 +173,7 @@ namespace dd
 	  if (p.second >= 0)
 	    _label = p.second;
 	}
+      return 0;
     }
     
     cv::Mat _img;

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -488,6 +488,11 @@ namespace dd
     jhead.AddMember("time",jout["time"],jpred.GetAllocator());
     jhead.AddMember("service",d["service"],jpred.GetAllocator());
     jpred.AddMember("head",jhead,jpred.GetAllocator());
+    if (ad_data.getobj("parameters").getobj("output").has("measure"))
+      {
+	jpred.AddMember("body",jout,jpred.GetAllocator());
+	return jpred;
+      }
     JVal jbody(rapidjson::kObjectType);
     if (jout.HasMember("predictions"))
       jbody.AddMember("predictions",jout["predictions"],jpred.GetAllocator());

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -485,7 +485,6 @@ namespace dd
     out.toJVal(jpred,jout);
     JVal jhead(rapidjson::kObjectType);
     jhead.AddMember("method","/predict",jpred.GetAllocator());
-    jhead.AddMember("time",jout["time"],jpred.GetAllocator());
     jhead.AddMember("service",d["service"],jpred.GetAllocator());
     jpred.AddMember("head",jhead,jpred.GetAllocator());
     if (ad_data.getobj("parameters").getobj("output").has("measure"))
@@ -493,6 +492,7 @@ namespace dd
 	jpred.AddMember("body",jout,jpred.GetAllocator());
 	return jpred;
       }
+    jhead.AddMember("time",jout["time"],jpred.GetAllocator());
     JVal jbody(rapidjson::kObjectType);
     if (jout.HasMember("predictions"))
       jbody.AddMember("predictions",jout["predictions"],jpred.GetAllocator());

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -483,16 +483,18 @@ namespace dd
     JDoc jpred = dd_ok_200();
     JVal jout(rapidjson::kObjectType);
     out.toJVal(jpred,jout);
+    bool has_measure = ad_data.getobj("parameters").getobj("output").has("measure");
     JVal jhead(rapidjson::kObjectType);
     jhead.AddMember("method","/predict",jpred.GetAllocator());
     jhead.AddMember("service",d["service"],jpred.GetAllocator());
+    if (!has_measure)
+      jhead.AddMember("time",jout["time"],jpred.GetAllocator());
     jpred.AddMember("head",jhead,jpred.GetAllocator());
-    if (ad_data.getobj("parameters").getobj("output").has("measure"))
+    if (has_measure)
       {
 	jpred.AddMember("body",jout,jpred.GetAllocator());
 	return jpred;
       }
-    jhead.AddMember("time",jout["time"],jpred.GetAllocator());
     JVal jbody(rapidjson::kObjectType);
     if (jout.HasMember("predictions"))
       jbody.AddMember("predictions",jout["predictions"],jpred.GetAllocator());

--- a/src/txtinputfileconn.cc
+++ b/src/txtinputfileconn.cc
@@ -70,7 +70,7 @@ namespace dd
     // list files and classes
     std::vector<std::pair<std::string,int>> lfiles; // labeled files
     std::unordered_map<int,std::string> hcorresp; // correspondence class number / class name
-    if (_ctfc->_train)
+    if (!subdirs.empty())
       {
 	int cl = 0;
 	auto uit = subdirs.begin();
@@ -78,8 +78,9 @@ namespace dd
 	  {
 	    std::unordered_set<std::string> subdir_files;
 	    if (fileops::list_directory((*uit),true,false,subdir_files))
-	      throw InputConnectorBadParamException("failed reading image data sub-directory " + (*uit));
-	    hcorresp.insert(std::pair<int,std::string>(cl,dd_utils::split((*uit),'/').back()));
+	      throw InputConnectorBadParamException("failed reading text data sub-directory " + (*uit));
+	    if (_ctfc->_train)
+	      hcorresp.insert(std::pair<int,std::string>(cl,dd_utils::split((*uit),'/').back()));
 	    auto fit = subdir_files.begin();
 	    while(fit!=subdir_files.end()) // XXX: re-iterating the file is not optimal
 	      {
@@ -117,18 +118,21 @@ namespace dd
 
     // post-processing
     size_t initial_vocab_size = _ctfc->_vocab.size();
-    auto vhit = _ctfc->_vocab.begin();
-    while(vhit!=_ctfc->_vocab.end())
+    if (_ctfc->_train)
       {
-	if ((*vhit).second._total_count < _ctfc->_min_count)
-	  vhit = _ctfc->_vocab.erase(vhit);
-	else ++vhit;
+	auto vhit = _ctfc->_vocab.begin();
+	while(vhit!=_ctfc->_vocab.end())
+	  {
+	    if ((*vhit).second._total_count < _ctfc->_min_count)
+	      vhit = _ctfc->_vocab.erase(vhit);
+	    else ++vhit;
+	  }
       }
-    if (initial_vocab_size != _ctfc->_vocab.size())
+    if (_ctfc->_train && initial_vocab_size != _ctfc->_vocab.size())
       {
 	// update pos
 	int pos = 0;
-	vhit = _ctfc->_vocab.begin();
+	auto vhit = _ctfc->_vocab.begin();
 	while(vhit!=_ctfc->_vocab.end())
 	  {
 	    (*vhit).second._pos = pos;

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -576,6 +576,18 @@ TEST(caffeapi,service_train_txt)
   ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.5);
   ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
 
+  // predict with measure
+  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"parameters\":{\"mllib\":{\"gpu\":true,\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]}},\"data\":[\"" + n20_repo +"news20\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(200,jd["status"]["code"].GetInt());
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"].HasMember("measure"));
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
+  
   // remove service
   jstr = "{\"clear\":\"full\"}";
   joutstr = japi.jrender(japi.service_delete(sname,jstr));


### PR DESCRIPTION
This PR allows the `POST /predict` call to return accuracy `measure` (see [output connectors API](http://www.deepdetect.com/api/?shell#output-connectors)).

This is useful now for testing an already trained model, and later on for ensembling.

Example call:
- create text service from already trained model (as created following http://www.deepdetect.com/tutorials/txt-training/):
```
curl -X PUT "http://localhost:8080/services/n20" -d "{\"mllib\":\"caffe\",\"description\":\"newsgroup classification service\",\"type\":\"supervised\",\"parameters\":{\"input\":{\"connector\":\"txt\"},\"mllib\":{\"nclasses\":20}},\"model\":{\"repository\":\"/path/to/models/n20\"}}"
```
- test call with `predict` resource:
```
curl -X POST 'http://localhost:8080/predict' -d '{"service":"n20","parameters":{"mllib":{"gpu":true},"output":{"measure":["f1"]}},"data":["/path/to/news20-18828/"]}'
```
yields something like:
```
{"status":{"code":200,"msg":"OK"},"head":{"method":"/predict","time":18271.0,"service":"n20"},"body":{"measure":{"f1":0.8152690151793434,"recall":0.8219119954158582,precision":0.8087325557838578,"accp":0.815365025466893}}}
```