### PR TITLE
Recovery from Caffe GPU memory overload on net prediction

### DIFF
--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1224,7 +1224,10 @@ namespace dd
     if (ad.has("gpu"))
       _gpu = ad.get("gpu").get<bool>();
     if (ad.has("gpuid"))
-      _gpuid = ad.get("gpuid").get<int>();
+      {
+	_gpuid = ad.get("gpuid").get<int>();
+	_gpu = true;
+      }
     if (ad.has("nclasses"))
       _nclasses = ad.get("nclasses").get<int>();
     if (ad.has("regression") && ad.get("regression").get<bool>())


### PR DESCRIPTION
GPU memory overload with Caffe appears to be eratically recoverable. 

This PR makes the recovery deterministically possible. However it is obversed that multiple predict calls within memory bounds are often necessary for the service to recover after a GPU memory overflow.

For instance, on a 4GB using `resnet_152`, passing more than 7 or 8 images leads to 

```
{"status":{"code":500,"msg":"InternalError","dd_code":1007,"dd_msg":"src/caffe/util/im2col.cu:61 / Check failed (custom): (error) == (cudaSuccess)"}}
```

In our tests, trying a few more `predict` calls on the same service, with less images per batch, unlocks the memory and allows for the service to proceed correctly.

Note that deleting the service, re-creating it, and passing less images on the first `predict` call does not appear to prevent the need for a few calls to recover the GPU memory.

The same behavior is observed with and without CUDNN. While this PR is a step forward toward flawless recovery, the root causes of the behavior described above remain unknown at this stage, and more investigation is required.