### PR TITLE
Support for sparse computations and sparse neural network layers with (custom) Caffe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
+	URL https://github.com/beniz/caffe/archive/master.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -82,7 +82,7 @@ ExternalProject_Add(
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
+	URL https://github.com/beniz/caffe/archive/master.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -93,7 +93,7 @@ ExternalProject_Add(
       caffe_dd
       PREFIX caffe_dd
       INSTALL_DIR ${CMAKE_BINARY_DIR}
-      URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
+      URL https://github.com/beniz/caffe/archive/master.tar.gz
       CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
       INSTALL_COMMAND ""
       BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master_dd_integ_parse.tar.gz
+	URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master_dd_integ.tar.gz
+	URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -76,7 +76,7 @@ ExternalProject_Add(
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master_dd_integ.tar.gz
+	URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -87,7 +87,7 @@ ExternalProject_Add(
       caffe_dd
       PREFIX caffe_dd
       INSTALL_DIR ${CMAKE_BINARY_DIR}
-      URL https://github.com/beniz/caffe/archive/master_dd_integ.tar.gz
+      URL https://github.com/beniz/caffe/archive/master_dd_integ_sparse.tar.gz
       CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && make -j${N}
       INSTALL_COMMAND ""
       BUILD_IN_SOURCE 1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Current features include:
 - no database dependency and sync, all information and model parameters organized and available from the filesystem
 - flexible template output format to simplify connection to external applications
 - templates for the most useful neural architectures (e.g. Googlenet, Alexnet, ResNet, convnet, character-based convnet, mlp, logistic regression)
+- support for sparse features and computations on both GPU and CPU
 
 ##### Documentation
 
@@ -79,7 +80,7 @@ None outside of C++ compiler and make
 
 ##### Caffe version
 
-By default DeepDetect automatically relies on a modified version of Caffe, https://github.com/beniz/caffe/tree/master_dd_integ
+By default DeepDetect automatically relies on a modified version of Caffe, https://github.com/beniz/caffe/tree/master
 
 ##### Implementation
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,9 +3,8 @@ if (NOT CUDA_FOUND)
   add_definitions(-DCPU_ONLY)
 endif()
 
-set(ddetect_SOURCES deepdetect.h deepdetect.cc caffelib.h caffelib.cc mllibstrategy.h mlmodel.h mlservice.h caffemodel.h caffemodel.cc inputconnectorstrategy.h imginputfileconn.h csvinputfileconn.h csvinputfileconn.cc txtinputfileconn.h txtinputfileconn.cc caffeinputconns.h caffeinputconns.cc commandlineapi.h commandlineapi.cc commandlinejsonapi.h commandlinejsonapi.cc apidata.h apidata.cc jsonapi.h jsonapi.cc httpjsonapi.cc httpjsonapi.h ext/rmustache/mustache.h ext/rmustache/mustache.cc)
+set(ddetect_SOURCES deepdetect.h deepdetect.cc caffelib.h caffelib.cc mllibstrategy.h mlmodel.h mlservice.h caffemodel.h caffemodel.cc inputconnectorstrategy.h imginputfileconn.h csvinputfileconn.h csvinputfileconn.cc svminputfileconn.h svminputfileconn.cc txtinputfileconn.h txtinputfileconn.cc caffeinputconns.h caffeinputconns.cc commandlineapi.h commandlineapi.cc commandlinejsonapi.h commandlinejsonapi.cc apidata.h apidata.cc jsonapi.h jsonapi.cc httpjsonapi.cc httpjsonapi.h ext/rmustache/mustache.h ext/rmustache/mustache.cc)
 
-#add_library(ddetect deepdetect.h deepdetect.cc caffelib.h caffelib.cc mllibstrategy.h mlmodel.h mlservice.h caffemodel.h caffemodel.cc inputconnectorstrategy.h imginputfileconn.h csvinputfileconn.h csvinputfileconn.cc txtinputfileconn.h txtinputfileconn.cc caffeinputconns.h caffeinputconns.cc commandlineapi.h commandlineapi.cc commandlinejsonapi.h commandlinejsonapi.cc apidata.h apidata.cc jsonapi.h jsonapi.cc httpjsonapi.cc httpjsonapi.h ext/rmustache/mustache.h ext/rmustache/mustache.cc)
 if (USE_XGBOOST)
   list(APPEND ddetect_SOURCES xgblib.cc xgblib.h xgbmodel.cc xgbmodel.h xgbinputconns.cc xgbinputconns.h)
 endif()

--- a/src/caffeinputconns.cc
+++ b/src/caffeinputconns.cc
@@ -894,8 +894,6 @@ namespace dd
 		SparseDatum datum;
 		datum.ParseFromString(cursor->value());
 		_channels = datum.size();
-		std::cerr << "acquired channels=" << _channels << std::endl;
-		exit(1);
 	      }
 	    ++_db_batchsize;
 	    cursor->Next();

--- a/src/caffeinputconns.cc
+++ b/src/caffeinputconns.cc
@@ -955,16 +955,15 @@ namespace dd
   }
 
   void SVMCaffeInputFileConn::add_train_svmline(const int &label,
-						const std::unordered_map<int,double> &vals)
+						const std::unordered_map<int,double> &vals,
+						const int &count)
   {
     if (!_db)
       {
-	SVMInputFileConn::add_train_svmline(label,vals);
+	SVMInputFileConn::add_train_svmline(label,vals,count);
 	return;
       }
 
-    static int count = 0;
-    
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
     
@@ -983,7 +982,7 @@ namespace dd
     _txn->Put(std::string(key_cstr, length), out);
     _db_batchsize++;
     
-    if (++count % 10000 == 0) {
+    if (count % 10000 == 0) {
       // commit db
       _txn->Commit();
       _txn.reset(_tdb->NewTransaction());
@@ -992,16 +991,15 @@ namespace dd
   }
 
   void SVMCaffeInputFileConn::add_test_svmline(const int &label,
-					       const std::unordered_map<int,double> &vals)
+					       const std::unordered_map<int,double> &vals,
+					       const int &count)
   {
     if (!_db)
       {
-	SVMInputFileConn::add_test_svmline(label,vals);
+	SVMInputFileConn::add_test_svmline(label,vals,count);
 	return;
       }
-    
-      static int count = 0;
-    
+
     const int kMaxKeyLength = 256;
     char key_cstr[kMaxKeyLength];
     
@@ -1020,7 +1018,7 @@ namespace dd
     _ttxn->Put(std::string(key_cstr, length), out);
     _db_testbatchsize++;
 
-    if (++count % 10000 == 0) {
+    if (count % 10000 == 0) {
       // commit db
       _ttxn->Commit();
       _ttxn.reset(_ttdb->NewTransaction());

--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -874,9 +874,11 @@ namespace dd
     }
 
     virtual void add_train_svmline(const int &label,
-				   const std::unordered_map<int,double> &vals);
+				   const std::unordered_map<int,double> &vals,
+				   const int &count);
     virtual void add_test_svmline(const int &label,
-				  const std::unordered_map<int,double> &vals);
+				  const std::unordered_map<int,double> &vals,
+				  const int &count);
 
     void transform(const APIData &ad)
     {
@@ -897,6 +899,7 @@ namespace dd
 	    dbad.add("test_db",_model_repo + "/" + _test_dbfullname);
 	  std::vector<APIData> vdbad = {dbad};
 	  const_cast<APIData&>(ad).add("db",vdbad);
+	  serialize_vocab();
 	}
       else
 	{
@@ -944,13 +947,10 @@ namespace dd
 	    ++hit;
 	  }
 	datum.set_nnz(nelts);
-	//std::cerr << "datum size=" << channels() << std::endl;
 	datum.set_size(channels());
 	return datum;
       }
 
-    //TODO: get_dv_test & get_dv_test_db
-    
     std::vector<caffe::SparseDatum> get_dv_test_sparse_db(const int &num);
     std::vector<caffe::SparseDatum> get_dv_test_sparse(const int &num)
       {

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -2282,13 +2282,18 @@ namespace dd
 	//debug
 	LOG(INFO) << "batch_size=" << batch_size << " / test_batch_size=" << test_batch_size << " / test_iter=" << test_iter << std::endl;
 	//debug
+
+	if (batch_size == 0)
+	  throw MLLibBadParamException("auto batch size set to zero: MemoryData input requires batch size to be a multiple of training set");
       }
   }
   
   template class CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>;
   template class CaffeLib<CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>;
   template class CaffeLib<TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>;
+  template class CaffeLib<SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>;
   template class CaffeLib<ImgCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
   template class CaffeLib<CSVCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
   template class CaffeLib<TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
+  template class CaffeLib<SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>;
 }

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -307,16 +307,13 @@ namespace dd
 		  {
 		    lparam = net_param.mutable_layer(0);
 		    lparam->set_type("MemorySparseData");
-		    //lparam->mutable_memory_data_param()->set_channels(1);
 		  }	
 		
 		lparam = net_param.mutable_layer(1); // test layer
 		lparam->set_type("MemorySparseData");
-		//lparam->mutable_memory_data_param()->set_channels(1);
 		
 		dlparam = deploy_net_param.mutable_layer(0);
 		dlparam->set_type("MemorySparseData");
-		//dlparam->mutable_memory_data_param()->set_channels(1);
 	      }
 	  }
 	else if (l > 0 && model_tmpl != "lregression")
@@ -326,7 +323,13 @@ namespace dd
 	  }
 	if (model_tmpl == "lregression") // one pass for lregression
 	  {
-	    //TODO: in case sparse, SparseInnerProduct
+	    if (sparse)
+	      {
+		lparam = net_param.mutable_layer(2);
+		lparam->set_type("SparseInnerProduct");
+		dlparam = deploy_net_param.mutable_layer(1);
+		dlparam->set_type("SparseInnerProduct");
+	      }
 	    return;
 	  }
 
@@ -1685,8 +1688,6 @@ namespace dd
 	  nout = _ntargets;
 	ad_res.add("nclasses",_nclasses);
 	inputc.reset_dv_test();
-	//std::vector<caffe::Datum> dv;
-	//while(!(dv=inputc.get_dv_test(test_batch_size,has_mean_file)).empty()) //TODO: dv_test_sparse
 	while(true)
 	  {
 	    size_t dv_size = 0;
@@ -1781,8 +1782,6 @@ namespace dd
 		else
 		  {
 		    std::vector<double> target;
-		    /*for (int k=inputc.channels();k<dv.at(j).float_data_size();k++)
-		      target.push_back(dv.at(j).float_data(k));*/ //TODO: reactivate
 		    for (size_t k=0;k<dv_float_data.at(j).size();k++)
 		      target.push_back(dv_float_data.at(j).at(k));
 		    for (int k=0;k<nout;k++)

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -114,7 +114,7 @@ namespace dd
 	caffe::NetParameter net_param,deploy_net_param;
 	caffe::ReadProtoFromTextFile(dest_net,&net_param); //TODO: catch parsing error (returns bool true on success)
 	caffe::ReadProtoFromTextFile(dest_deploy_net,&deploy_net_param);
-	configure_mlp_template(ad,_regression,_ntargets,_nclasses,net_param,deploy_net_param);
+	configure_mlp_template(ad,_regression,this->_inputc._sparse,_ntargets,_nclasses,net_param,deploy_net_param);
 	caffe::WriteProtoToTextFile(net_param,dest_net);
 	caffe::WriteProtoToTextFile(deploy_net_param,dest_deploy_net);
       }
@@ -171,6 +171,7 @@ namespace dd
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
   void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::configure_mlp_template(const APIData &ad,
 												   const bool &regression,
+												   const bool &sparse,
 												   const int &targets,
 												   const int &cnclasses,
 												   caffe::NetParameter &net_param,
@@ -292,11 +293,30 @@ namespace dd
 		// fixing input layer so that it takes data in from db
 		lparam = net_param.mutable_layer(0);
 		lparam->clear_memory_data_param();
-		lparam->set_type("Data");
+		if (!sparse)
+		  lparam->set_type("Data");
+		else lparam->set_type("SparseData");
 		caffe::DataParameter *ldparam = lparam->mutable_data_param();
 		ldparam->set_source("train.lmdb");
 		ldparam->set_batch_size(1000); // dummy value, updated before training
 		ldparam->set_backend(caffe::DataParameter_DB_LMDB);
+	      }
+	    if (sparse)
+	      {
+		if (!db)
+		  {
+		    lparam = net_param.mutable_layer(0);
+		    lparam->set_type("MemorySparseData");
+		    //lparam->mutable_memory_data_param()->set_channels(1);
+		  }	
+		
+		lparam = net_param.mutable_layer(1); // test layer
+		lparam->set_type("MemorySparseData");
+		//lparam->mutable_memory_data_param()->set_channels(1);
+		
+		dlparam = deploy_net_param.mutable_layer(0);
+		dlparam->set_type("MemorySparseData");
+		//dlparam->mutable_memory_data_param()->set_channels(1);
 	      }
 	  }
 	else if (l > 0 && model_tmpl != "lregression")
@@ -306,6 +326,7 @@ namespace dd
 	  }
 	if (model_tmpl == "lregression") // one pass for lregression
 	  {
+	    //TODO: in case sparse, SparseInnerProduct
 	    return;
 	  }
 
@@ -321,7 +342,9 @@ namespace dd
 	  }
 	else lparam = net_param.add_layer();
 	lparam->set_name(last_ip);
-	lparam->set_type("InnerProduct");
+	if (rl == 2 && sparse)
+	  lparam->set_type("SparseInnerProduct");
+	else lparam->set_type("InnerProduct");
 	lparam->add_bottom(prec_ip);
 	lparam->add_top(last_ip);
 	caffe::InnerProductParameter *ipp = lparam->mutable_inner_product_param();
@@ -342,7 +365,9 @@ namespace dd
 	  }
 	else dlparam = deploy_net_param.add_layer();
 	dlparam->set_name(last_ip);
-	dlparam->set_type("InnerProduct");
+	if (drl == 1 && sparse)
+	  dlparam->set_type("SparseInnerProduct");
+	else dlparam->set_type("InnerProduct");
 	dlparam->add_bottom(prec_ip);
 	dlparam->add_top(last_ip);
 	ipp = dlparam->mutable_inner_product_param();
@@ -1272,6 +1297,8 @@ namespace dd
     TInputConnectorStrategy inputc(this->_inputc);
     this->_inputc._dv.clear();
     this->_inputc._dv_test.clear();
+    this->_inputc._dv_sparse.clear();
+    this->_inputc._dv_test_sparse.clear();
     this->_inputc._ids.clear();
     inputc._train = true;
     APIData cad = ad;
@@ -1406,29 +1433,36 @@ namespace dd
 	delete solver;
 	throw;
       }
-    if (!inputc._dv.empty())
+    if (!inputc._dv.empty() || !inputc._dv_sparse.empty())
       {
 	LOG(INFO) << "filling up net prior to training\n";
 	try {
-	  if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->net()->layers()[0]) == 0)
+	  if (!inputc._sparse)
 	    {
-	      delete solver;
-	      throw MLLibBadParamException("solver's net's first layer is required to be of MemoryData type");
+	      if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->net()->layers()[0]) == 0)
+		{
+		  delete solver;
+		  throw MLLibBadParamException("solver's net's first layer is required to be of MemoryData type");
+		}
+	      boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->net()->layers()[0])->AddDatumVector(inputc._dv);
 	    }
-	  boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->net()->layers()[0])->AddDatumVector(inputc._dv);
+	  else
+	    {
+	      if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(solver->net()->layers()[0]) == 0)
+		{
+		  delete solver;
+		  throw MLLibBadParamException("solver's net's first layer is required to be of MemorySparseData type");
+		}
+	      boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(solver->net()->layers()[0])->AddDatumVector(inputc._dv_sparse);
+	    }
 	}
 	catch(std::exception &e)
 	  {
 	    delete solver;
 	    throw;
 	  }
-	/*if (!solver->test_nets().empty())
-	  {
-	    if (!inputc._dv_test.empty())
-	      boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->test_nets().at(0)->layers()[0])->AddDatumVector(inputc._dv_test);
-	    else boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(solver->test_nets().at(0)->layers()[0])->AddDatumVector(inputc._dv);
-	    }*/
 	inputc._dv.clear();
+	inputc._dv_sparse.clear();
 	inputc._ids.clear();
       }
     if (this->_mlmodel.read_from_repository(this->_mlmodel._repo))
@@ -1583,6 +1617,7 @@ namespace dd
     if (!this->_tjob_running.load())
       {
 	inputc._dv_test.clear();
+	inputc._dv_test_sparse.clear();
 	return 0;
       }
     
@@ -1598,7 +1633,8 @@ namespace dd
     // test
     test(_net,ad,inputc,test_batch_size,has_mean_file,out);
     inputc._dv_test.clear();
-        
+    inputc._dv_test_sparse.clear();
+
     // add whatever the input connector needs to transmit out
     inputc.response_params(out);
 
@@ -1648,35 +1684,91 @@ namespace dd
 	  nout = _ntargets;
 	ad_res.add("nclasses",_nclasses);
 	inputc.reset_dv_test();
-	std::vector<caffe::Datum> dv;
-	while(!(dv=inputc.get_dv_test(test_batch_size,has_mean_file)).empty())
+	//std::vector<caffe::Datum> dv;
+	//while(!(dv=inputc.get_dv_test(test_batch_size,has_mean_file)).empty()) //TODO: dv_test_sparse
+	while(true)
 	  {
+	    size_t dv_size = 0;
+	    std::vector<float> dv_labels;
+	    std::vector<std::vector<double>> dv_float_data;
 	    try
 	      {
-		if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0]) == 0)
-		  throw MLLibBadParamException("test net's first layer is required to be of MemoryData type");
-		boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0])->set_batch_size(dv.size());
-		boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0])->AddDatumVector(dv);
+		if (!inputc._sparse)
+		  {
+		    std::vector<caffe::Datum> dv = inputc.get_dv_test(test_batch_size,has_mean_file);
+		    if (dv.empty())
+		      break;
+		    dv_size = dv.size();
+		    for (size_t s=0;s<dv_size;s++)
+		      {
+			dv_labels.push_back(dv.at(s).label());
+			if (_ntargets > 1)
+			  {
+			    std::vector<double> vals;
+			    for (int k=inputc.channels();k<dv.at(s).float_data_size();k++)
+			      vals.push_back(dv.at(s).float_data(k));
+			    dv_float_data.push_back(vals);
+			  }
+		      }
+		    if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0]) == 0)
+		      throw MLLibBadParamException("test net's first layer is required to be of MemoryData type");
+		    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0])->set_batch_size(dv.size());
+		    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(net->layers()[0])->AddDatumVector(dv);
+		  }
+		else
+		  {
+		    std::vector<caffe::SparseDatum> dv = inputc.get_dv_test_sparse(test_batch_size);
+		    if (dv.empty())
+		      break;
+		    dv_size = dv.size();
+		    for (size_t s=0;s<dv_size;s++)
+		      {
+			dv_labels.push_back(dv.at(s).label());
+			//TODO: no float_data in SparseDatum (since it is not sparse...)
+			/*if (_ntargets > 1)
+			  {
+			    std::vector<double> vals;
+			    for (int k=inputc.channels();k<dv.at(s).float_data_size();k++)
+			      vals.push_back(dv.at(s).float_data(k));
+			    dv_float_data.push_back(vals);
+			    }*/
+		      }
+		    if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0]) == 0)
+		      throw MLLibBadParamException("test net's first layer is required to be of MemorySparseData type");
+		    boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0])->set_batch_size(dv.size());
+		    boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0])->AddDatumVector(dv);
+		  }
 	      }
 	    catch(std::exception &e)
 	      {
 		// XXX: might want to clean up here...
+		std::cerr << "exception while filling up test input layer\n";
 		throw;
 	      }
 	    float loss = 0.0;
-	    std::vector<Blob<float>*> lresults = net->Forward(&loss);
+	    std::vector<Blob<float>*> lresults;
+	    try
+	      {
+		lresults = net->Forward(&loss);
+	      }
+	    catch(std::exception &e)
+	      {
+		std::cerr << "exception in test forward pass\n";
+		throw;
+	      }
 	    int slot = lresults.size() - 1;
 	    if (_regression && _ntargets > 1) // slicing is involved
 	      slot--; // labels appear to be last
 	    int scount = lresults[slot]->count();
-	    int scperel = scount / dv.size();
-	    for (int j=0;j<(int)dv.size();j++)
+	    int scperel = scount / dv_size;
+	    for (int j=0;j<(int)dv_size;j++)
 	      {
 		APIData bad;
 		std::vector<double> predictions;
 		if (!_regression || _ntargets == 1)
 		  {
-		    double target = dv.at(j).label();
+		    //double target = dv.at(j).label();
+		    double target = dv_labels.at(j);
 		    for (int k=0;k<nout;k++)
 		      {
 			predictions.push_back(lresults[slot]->cpu_data()[j*scperel+k]);
@@ -1686,8 +1778,10 @@ namespace dd
 		else
 		  {
 		    std::vector<double> target;
-		    for (int k=inputc.channels();k<dv.at(j).float_data_size();k++)
-		      target.push_back(dv.at(j).float_data(k));
+		    /*for (int k=inputc.channels();k<dv.at(j).float_data_size();k++)
+		      target.push_back(dv.at(j).float_data(k));*/ //TODO: reactivate
+		    for (size_t k=0;k<dv_float_data.at(j).size();k++)
+		      target.push_back(dv_float_data.at(j).at(k));
 		    for (int k=0;k<nout;k++)
 		      {
 			predictions.push_back(lresults[slot]->cpu_data()[j*scperel+k]);
@@ -1698,7 +1792,7 @@ namespace dd
 		std::vector<APIData> vad = { bad };
 		ad_res.add(std::to_string(tresults+j),vad);
 	      }
-	    tresults += dv.size();
+	    tresults += dv_size;
 	    mean_loss += loss;
 	  }
 	std::vector<std::string> clnames;
@@ -1733,6 +1827,7 @@ namespace dd
     APIData ad_output = ad.getobj("parameters").getobj("output");
     if (ad_output.has("measure"))
       {
+	std::cerr << "\ntest measure sparsity=" << inputc._sparse << std::endl;
 	APIData cad = ad;
 	cad.add("has_mean_file",this->_mlmodel._has_mean_file);
 	try
@@ -1749,7 +1844,7 @@ namespace dd
 	  {
 	    APIData ad_net = ad_mllib.getobj("net");
 	    if (ad_net.has("test_batch_size"))
-	  batch_size = ad_net.get("test_batch_size").get<int>();
+	      batch_size = ad_net.get("test_batch_size").get<int>();
 	  }
 
 	bool has_mean_file = this->_mlmodel._has_mean_file;
@@ -1811,14 +1906,29 @@ namespace dd
       }
     try
       {
-	if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0]) == 0)
+	if (!inputc._sparse)
 	  {
-	    delete _net;
-	    _net = nullptr;
-	    throw MLLibBadParamException("deploy net's first layer is required to be of MemoryData type");
+	    if (boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0]) == 0)
+	      {
+		delete _net;
+		_net = nullptr;
+		throw MLLibBadParamException("deploy net's first layer is required to be of MemoryData type");
+	      }
+	    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->set_batch_size(batch_size);
+	    boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->AddDatumVector(inputc._dv_test);
 	  }
-	boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->set_batch_size(batch_size);
-	boost::dynamic_pointer_cast<caffe::MemoryDataLayer<float>>(_net->layers()[0])->AddDatumVector(inputc._dv_test);
+	else
+	  {
+	    if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(_net->layers()[0]) == 0)
+	      {
+		delete _net;
+		_net = nullptr;
+		throw MLLibBadParamException("deploy net's first layer is required to be of MemorySparseData type");
+	      }
+	    std::cerr << "predict with sparse data\n";
+	    boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(_net->layers()[0])->set_batch_size(batch_size);
+	    boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(_net->layers()[0])->AddDatumVector(inputc._dv_test_sparse);
+	  }
       }
     catch(std::exception &e)
       {
@@ -2046,7 +2156,7 @@ namespace dd
 		break;
 	      }
 	  }
-	else if (lparam->type() == "InnerProduct")
+	else if (lparam->type() == "InnerProduct" || lparam->type() == "SparseInnerProduct")
 	  {
 	    if (lparam->has_inner_product_param())
 	      {

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1726,14 +1726,11 @@ namespace dd
 		    for (size_t s=0;s<dv_size;s++)
 		      {
 			dv_labels.push_back(dv.at(s).label());
-			//TODO: no float_data in SparseDatum (since it is not sparse...)
-			/*if (_ntargets > 1)
+			if (_ntargets > 1)
 			  {
-			    std::vector<double> vals;
-			    for (int k=inputc.channels();k<dv.at(s).float_data_size();k++)
-			      vals.push_back(dv.at(s).float_data(k));
-			    dv_float_data.push_back(vals);
-			    }*/
+			    // SparseDatum has no float_data and source cannot be sliced
+			    throw MLLibBadParamException("sparse inputs cannot accomodate multi-target objectives, use single target instead");
+			  }
 		      }
 		    if (boost::dynamic_pointer_cast<caffe::MemorySparseDataLayer<float>>(net->layers()[0]) == 0)
 		      throw MLLibBadParamException("test net's first layer is required to be of MemorySparseData type");
@@ -1745,7 +1742,6 @@ namespace dd
 	      {
 		LOG(ERROR) << "Error while filling up network for testing";
 		// XXX: might want to clean up here...
-		std::cerr << "exception while filling up test input layer\n";
 		throw;
 	      }
 	    float loss = 0.0;
@@ -1771,7 +1767,6 @@ namespace dd
 		std::vector<double> predictions;
 		if (!_regression || _ntargets == 1)
 		  {
-		    //double target = dv.at(j).label();
 		    double target = dv_labels.at(j);
 		    for (int k=0;k<nout;k++)
 		      {

--- a/src/caffelib.h
+++ b/src/caffelib.h
@@ -26,6 +26,7 @@
 #include "caffemodel.h"
 #include "caffe/caffe.hpp"
 #include "caffe/layers/memory_data_layer.hpp"
+#include "caffe/layers/memory_sparse_data_layer.hpp"
 
 using caffe::Blob;
 
@@ -65,12 +66,14 @@ namespace dd
      * \brief configure an MLP template
      * @param ad the template data object
      * @param regression whether the net is a regressor
+     * @param sparse whether the inputs are sparse
      * @param cnclasses the number of output classes, if any
      * @param net_param the training net object
      * @param deploy_net_param the deploy net object
      */
     static void configure_mlp_template(const APIData &ad,
 				       const bool &regression,
+				       const bool &sparse,
 				       const int &targets,
 				       const int &cnclasses,
 				       caffe::NetParameter &net_param,

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -423,7 +423,7 @@ namespace dd
 
     int batch_size() const
     {
-      return _csvdata.size(); // XXX: what about test data size ?
+      return _csvdata.size();
     }
 
     int test_batch_size() const

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -303,6 +303,8 @@ namespace dd
 		  add_service(sname,std::move(MLService<CaffeLib,CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
 		else if (input == "txt")
 		  add_service(sname,std::move(MLService<CaffeLib,TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
+		else if (input == "svm")
+		  add_service(sname,std::move(MLService<CaffeLib,SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
 		else return dd_input_connector_not_found_1004();
 		if (JsonAPI::store_json_blob(cmodel._repo,jstr)) // store successful call json blob
 		  LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << cmodel._repo << std::endl;
@@ -315,6 +317,8 @@ namespace dd
 		  add_service(sname,std::move(MLService<CaffeLib,CSVCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
 		else if (input == "txt")
 		  add_service(sname,std::move(MLService<CaffeLib,TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
+		else if (input == "svm")
+		  add_service(sname,std::move(MLService<CaffeLib,SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
 		else return dd_input_connector_not_found_1004();
 		if (JsonAPI::store_json_blob(cmodel._repo,jstr)) // store successful call json blob
 		  LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << cmodel._repo << std::endl;

--- a/src/services.h
+++ b/src/services.h
@@ -28,6 +28,7 @@
 #include "inputconnectorstrategy.h"
 #include "imginputfileconn.h"
 #include "txtinputfileconn.h"
+#include "svminputfileconn.h"
 #include "outputconnectorstrategy.h"
 #include "caffelib.h"
 #ifdef USE_XGBOOST
@@ -44,9 +45,11 @@ namespace dd
   typedef mapbox::util::variant<MLService<CaffeLib,ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>,
     MLService<CaffeLib,CSVCaffeInputFileConn,SupervisedOutput,CaffeModel>,
     MLService<CaffeLib,TxtCaffeInputFileConn,SupervisedOutput,CaffeModel>,
+    MLService<CaffeLib,SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>,
     MLService<CaffeLib,ImgCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
     MLService<CaffeLib,CSVCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
-    MLService<CaffeLib,TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>
+    MLService<CaffeLib,TxtCaffeInputFileConn,UnsupervisedOutput,CaffeModel>,
+    MLService<CaffeLib,SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>
 #ifdef USE_XGBOOST
     ,MLService<XGBLib,CSVXGBInputFileConn,SupervisedOutput,XGBModel>,
     MLService<XGBLib,SVMXGBInputFileConn,SupervisedOutput,XGBModel>,

--- a/src/svminputfileconn.cc
+++ b/src/svminputfileconn.cc
@@ -1,0 +1,151 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2016 Emmanuel Benazera
+ * Author: Emmanuel Benazera <beniz@droidnik.fr>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "svminputfileconn.h"
+#include "utils/utils.hpp"
+#include <glog/logging.h>
+
+namespace dd
+{
+
+  /*- DDSvm -*/
+  int DDSvm::read_file(const std::string &fname)
+  {
+    if (_cifc)
+      {
+	_cifc->read_svm(_adconf,fname);
+	return 0;
+      }
+    else return -1;
+  }
+  
+  int DDSvm::read_mem(const std::string &content)
+  {
+    if (!_cifc)
+      return -1;
+    std::unordered_map<int,double> vals;
+    int label = -1;
+    int nlines = 0;
+    _cifc->read_svm_line(content,vals,label);
+    /*if (_cifc->_scale)
+      {
+	if (!_cifc->_train) // in prediction mode, on-the-fly scaling
+	  {
+	    _cifc->scale_vals(vals);
+	  }
+	else // in training mode, collect bounds, then scale in another pass over the data
+	  {
+	    if (_cifc->_min_vals.empty() && _cifc->_max_vals.empty())
+	      _cifc->_min_vals = _cifc->_max_vals = vals;
+	    for (size_t j=0;j<vals.size();j++)
+	      {
+		_cifc->_min_vals.at(j) = std::min(vals.at(j),_cifc->_min_vals.at(j));
+		_cifc->_max_vals.at(j) = std::max(vals.at(j),_cifc->_max_vals.at(j));
+	      }
+	  }
+	  }*/
+    _cifc->add_train_svmline(label,vals);
+    return 0;
+  }
+
+  void SVMInputFileConn::read_svm_line(const std::string &content,
+				       std::unordered_map<int,double> &vals,
+				       int &label)
+  {
+    bool fpos = true;
+    std::string col;
+    std::stringstream sh(content);
+    while(std::getline(sh,col,' '))
+      {
+	try
+	  {
+	    if (fpos)
+	      {
+		label = std::stod(col);
+		fpos = false;
+	      }
+	    std::vector<std::string> res = dd_utils::split(col,':');
+	    if (res.size() == 2)
+	      {
+		int fid = std::stoi(res.at(0));
+		vals.insert(std::pair<int,double>(fid,std::stod(res.at(1))));
+		_fids.insert(fid);
+	      }
+	  }
+	catch (std::invalid_argument &e)
+	  {
+	    throw InputConnectorBadParamException("error reading SVM format line: " + content);
+	  }
+      }
+  }
+  
+  void SVMInputFileConn::read_svm(const APIData &ad,
+				  const std::string &fname)
+  {
+    std::ifstream svm_file(fname,std::ios::binary);
+    LOG(INFO) << "SVM fname=" << fname << " / open=" << svm_file.is_open() << std::endl;
+    if (!svm_file.is_open())
+      throw InputConnectorBadParamException("cannot open file " + fname);
+  
+    // read data
+    int nlines = 0;
+    std::string hline;
+    while(std::getline(svm_file,hline))
+      {
+	//hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
+	std::unordered_map<int,double> vals;
+	int label;
+	read_svm_line(hline,vals,label);
+	add_train_svmline(label,vals);
+	++nlines;
+      }
+      svm_file.close();
+      LOG(INFO) << "read " << nlines << " lines from SVM data file";
+
+      if (!_svm_test_fname.empty())
+	{
+	  std::ifstream svm_test_file(_svm_test_fname,std::ios::binary);
+	  if (!svm_test_file.is_open())
+	    throw InputConnectorBadParamException("cannot open SVM test file " + fname);
+	  std::getline(svm_test_file,hline); // skip header line
+	  while(std::getline(svm_test_file,hline))
+	    {
+	      hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
+	      std::unordered_map<int,double> vals;
+	      int label;
+	      read_svm_line(hline,vals,label);
+	      add_test_svmline(label,vals);
+	    }
+	  svm_test_file.close();
+	}
+      
+      // shuffle before test selection, if any
+      shuffle_data(ad);
+      
+      std::cerr << "test_split=" << _test_split << std::endl;
+      if (_svm_test_fname.empty() && _test_split > 0)
+	{
+	  split_data();
+	  LOG(INFO) << "data split test size=" << _svmdata_test.size() << " / remaining data size=" << _svmdata.size() << std::endl;
+	}
+  }
+  
+}

--- a/src/svminputfileconn.cc
+++ b/src/svminputfileconn.cc
@@ -87,7 +87,7 @@ namespace dd
 	      {
 		int fid = std::stoi(res.at(0));
 		vals.insert(std::pair<int,double>(fid,std::stod(res.at(1))));
-		_fids.insert(fid);
+		//_fids.insert(fid);
 	      }
 	  }
 	catch (std::invalid_argument &e)
@@ -104,13 +104,36 @@ namespace dd
     LOG(INFO) << "SVM fname=" << fname << " / open=" << svm_file.is_open() << std::endl;
     if (!svm_file.is_open())
       throw InputConnectorBadParamException("cannot open file " + fname);
-  
-    // read data
-    int nlines = 0;
     std::string hline;
+
+    // first pass to get max index
+    std::string col;
     while(std::getline(svm_file,hline))
       {
-	//hline.erase(std::remove(hline.begin(),hline.end(),'\r'),hline.end());
+	bool fpos = true;
+      	std::stringstream sh(hline);
+	while(std::getline(sh,col,' '))
+	  {
+	    if (fpos)
+	      {
+		fpos = false;
+		continue;
+	      }
+	    std::vector<std::string> res = dd_utils::split(col,':');
+	    if (res.size() == 2)
+	      {
+		int fid = std::stoi(res.at(0));
+		_fids.insert(fid);
+	      }
+	  }
+      }
+    svm_file.clear();
+    svm_file.seekg(0,std::ios::beg);
+
+    // read data
+    int nlines = 0;
+    while(std::getline(svm_file,hline))
+      {
 	std::unordered_map<int,double> vals;
 	int label;
 	read_svm_line(hline,vals,label);

--- a/src/svminputfileconn.h
+++ b/src/svminputfileconn.h
@@ -159,9 +159,12 @@ namespace dd
 	      if (_test_split > 0.0)
 		split_data();
 	    }
+	  serialize_vocab();
 	}
       else // prediction mode
 	{
+	  if (_fids.empty())
+	    deserialize_vocab();
 	  for (size_t i=0;i<_uris.size();i++)
 	    {
 	      DataEl<DDSvm> ddsvm;
@@ -175,13 +178,15 @@ namespace dd
     }
 
     virtual void add_train_svmline(const int &label,
-				   const std::unordered_map<int,double> &vals)
+				   const std::unordered_map<int,double> &vals,
+				   const int &count)
     {
       _svmdata.emplace_back(label,std::move(vals));
     }
     
     virtual void add_test_svmline(const int &label,
-				  const std::unordered_map<int,double> &vals)
+				  const std::unordered_map<int,double> &vals,
+				  const int &count)
     {
       _svmdata.emplace_back(label,std::move(vals));
     }
@@ -205,8 +210,12 @@ namespace dd
     int feature_size() const
     {
       // total number of indices
-      return _fids.size();
+      return _max_id;
     }
+
+    // serialization of vocabulary
+    void serialize_vocab();
+    void deserialize_vocab(const bool &required=true);
 
     // options
     std::string _svm_fname;
@@ -217,6 +226,8 @@ namespace dd
     std::vector<SVMline> _svmdata;
     std::vector<SVMline> _svmdata_test;
     std::unordered_set<int> _fids; /**< feature ids. */
+    int _max_id = -1;
+    std::string _vocabfname = "vocab.dat";
   };
 
 }

--- a/src/svminputfileconn.h
+++ b/src/svminputfileconn.h
@@ -1,0 +1,224 @@
+/**
+ * DeepDetect
+ * Copyright (c) 2016 Emmanuel Benazera
+ * Author: Emmanuel Benazera <beniz@droidnik.fr>
+ *
+ * This file is part of deepdetect.
+ *
+ * deepdetect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * deepdetect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with deepdetect.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SVMINPUTFILECONN_H
+#define SVMINPUTFILECONN_H
+
+#include "inputconnectorstrategy.h"
+#include <random>
+#include <algorithm>
+
+namespace dd
+{
+  class SVMInputFileConn;
+
+  class DDSvm
+  {
+  public:
+    DDSvm() {}
+    ~DDSvm() {}
+
+    int read_file(const std::string &fname);
+    int read_mem(const std::string &content);
+    int read_dir(const std::string &dir)
+    {
+      throw InputConnectorBadParamException("uri " + dir + " is a directory, requires a file in libSVM format");
+    }
+    
+    SVMInputFileConn *_cifc = nullptr;
+    APIData _adconf;
+  };
+  
+  class SVMline
+  {
+  public:
+    SVMline(const int &label,
+	    const std::unordered_map<int,double> &v)
+      :_label(label),_v(v) {}
+    ~SVMline() {}
+    std::unordered_map<int,double> _v; /**< svm line data */
+    int _label; /**< svm line label. */
+  };
+
+  class SVMInputFileConn : public InputConnectorStrategy
+  {
+  public:
+    SVMInputFileConn()
+      :InputConnectorStrategy() {}
+    ~SVMInputFileConn() {}
+
+    void init(const APIData &ad)
+    {
+      fillup_parameters(ad);
+    }
+
+    void fillup_parameters(const APIData &ad_input)
+    {
+      if (ad_input.has("test_split"))
+	_test_split = ad_input.get("test_split").get<double>();
+    }
+
+    void shuffle_data(const APIData &ad)
+    {
+      if (ad.has("shuffle") && ad.get("shuffle").get<bool>())
+	{
+	  std::mt19937 g;
+	  if (ad.has("seed") && ad.get("seed").get<int>() >= 0)
+	    {
+	      g = std::mt19937(ad.get("seed").get<int>());
+	    }
+	  else
+	    {
+	      std::random_device rd;
+	      g = std::mt19937(rd());
+	    }
+	  std::shuffle(_svmdata.begin(),_svmdata.end(),g);
+	}
+    }
+
+    void split_data()
+    {
+      if (_test_split > 0.0)
+	{
+	  int split_size = std::floor(_svmdata.size() * (1.0-_test_split));
+	  auto chit = _svmdata.begin();
+	  auto dchit = chit;
+	  int cpos = 0;
+	  while(chit!=_svmdata.end())
+	    {
+	      if (cpos == split_size)
+		{
+		  if (dchit == _svmdata.begin())
+		    dchit = chit;
+		  _svmdata_test.push_back((*chit));
+		}
+	      else ++cpos;
+	      ++chit;
+	    }
+	  _svmdata.erase(dchit,_svmdata.end());
+	}
+    }
+
+    void transform(const APIData &ad)
+    {
+      get_data(ad);
+      APIData ad_input = ad.getobj("parameters").getobj("input");
+      fillup_parameters(ad_input);
+
+      // training from either file or memory.
+      if (_train)
+	{
+	  if (fileops::file_exists(_uris.at(0))) // training from file
+	    {
+	      _svm_fname = _uris.at(0);
+	      if (_uris.size() > 1)
+		_svm_test_fname = _uris.at(1);
+	    }
+	  if (!_svm_fname.empty()) // when training from file
+	    {
+	      DataEl<DDSvm> ddsvm;
+	      ddsvm._ctype._cifc = this;
+	      ddsvm._ctype._adconf = ad_input;
+	      ddsvm.read_element(_svm_fname);
+	    }
+	  else // training from posted data (in-memory)
+	    {
+	      for (size_t i=1;i<_uris.size();i++)
+		{
+		  DataEl<DDSvm> ddsvm;
+		  ddsvm._ctype._cifc = this;
+		  ddsvm._ctype._adconf = ad_input;
+		  ddsvm.read_element(_uris.at(i));
+		}
+	      /*if (_scale)
+		{
+		  for (size_t j=0;j<_svmdata.size();j++)
+		    {
+		      scale_vals(_svmdata.at(j)._v);
+		    }
+		    }*/
+	      shuffle_data(ad_input);
+	      if (_test_split > 0.0)
+		split_data();
+	    }
+	}
+      else // prediction mode
+	{
+	  for (size_t i=0;i<_uris.size();i++)
+	    {
+	      DataEl<DDSvm> ddsvm;
+	      ddsvm._ctype._cifc = this;
+	      ddsvm._ctype._adconf = ad_input;
+	      ddsvm.read_element(_uris.at(i));
+	    }
+	}
+      if (_svmdata.empty())
+	throw InputConnectorBadParamException("no data could be found");
+    }
+
+    virtual void add_train_svmline(const int &label,
+				   const std::unordered_map<int,double> &vals)
+    {
+      _svmdata.emplace_back(label,std::move(vals));
+    }
+    
+    virtual void add_test_svmline(const int &label,
+				  const std::unordered_map<int,double> &vals)
+    {
+      _svmdata.emplace_back(label,std::move(vals));
+    }
+
+    void read_svm(const APIData &ad,
+		  const std::string &fname);
+    void read_svm_line(const std::string &content,
+		       std::unordered_map<int,double> &vals,
+		       int &label);
+
+    int batch_size() const
+    {
+      return _svmdata.size();
+    }
+
+    int test_batch_size() const
+    {
+      return _svmdata_test.size();
+    }
+
+    int feature_size() const
+    {
+      // total number of indices
+      return _fids.size();
+    }
+
+    // options
+    std::string _svm_fname;
+    std::string _svm_test_fname;
+    double _test_split = -1;
+
+    // data
+    std::vector<SVMline> _svmdata;
+    std::vector<SVMline> _svmdata_test;
+    std::unordered_set<int> _fids; /**< feature ids. */
+  };
+
+}
+
+#endif

--- a/src/txtinputfileconn.cc
+++ b/src/txtinputfileconn.cc
@@ -330,7 +330,7 @@ namespace dd
       {
 	std::vector<std::string> tokens = dd_utils::split(line,',');
 	std::string key = tokens.at(0);
-	int pos = atoi(tokens.at(1).c_str());
+	int pos = std::atoi(tokens.at(1).c_str());
 	_vocab.emplace(std::make_pair(key,Word(pos)));
       }
     std::cerr << "loaded vocabulary of size=" << _vocab.size() << std::endl;

--- a/src/txtinputfileconn.h
+++ b/src/txtinputfileconn.h
@@ -71,6 +71,7 @@ namespace dd
     void reset() {}
     void get_elt(std::string &key, T &val) const { (void)key; (void)val; }
     bool has_elt() const { return false; }
+    size_t size() const { return 0; }
     
     float _target = -1; /**< class target in training mode. */
     std::string _uri;
@@ -121,6 +122,11 @@ namespace dd
       return _vit != _v.end();
     }
     
+    size_t size() const
+    {
+      return _v.size();
+    }
+
     std::unordered_map<std::string,double> _v; /**< words as (<pos,val>). */
     std::unordered_map<std::string,double>::iterator _vit;
   };
@@ -155,6 +161,11 @@ namespace dd
     bool has_elt() const
     {
       return _vit != _v.end();
+    }
+
+    size_t size() const 
+    {
+      return _v.size();
     }
     
     std::vector<uint32_t> _v;

--- a/templates/caffe/lregression/lregression_solver.prototxt
+++ b/templates/caffe/lregression/lregression_solver.prototxt
@@ -3,9 +3,8 @@ test_iter: 1
 test_interval: 100
 base_lr: 0.1
 momentum: 0.9
-#weight_decay: 0.00001
+weight_decay: 0.00001
 #lr_policy: "fixed"
-weight_decay: 0.0005
 lr_policy: "inv"
 gamma: 0.0001
 power: 0.75

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -595,6 +595,57 @@ TEST(caffeapi,service_train_txt)
   rmdir(n20_repo_loc.c_str());
 }
 
+TEST(caffeapi,service_train_txt_sparse)
+{
+  // create service
+  JsonAPI japi;
+  std::string n20_repo_loc = "n20";
+  mkdir(n20_repo_loc.c_str(),0777);
+  std::string sname = "my_service";
+  std::string jstr = "{\"mllib\":\"caffe\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  n20_repo_loc + "\",\"templates\":\"" + model_templates_repo  + "\"},\"parameters\":{\"input\":{\"connector\":\"txt\",\"sparse\":true},\"mllib\":{\"template\":\"mlp\",\"nclasses\":20,\"db\":false}}}";
+  std::string joutstr = japi.jrender(japi.service_create(sname,jstr));
+  ASSERT_EQ(created_str,joutstr);
+
+  // train
+  std::string jtrainstr = "{\"service\":\"" + sname + "\",\"async\":false,\"parameters\":{\"input\":{\"test_split\":0.2,\"shuffle\":true,\"min_count\":10,\"min_word_length\":3,\"count\":false,\"db\":false},\"mllib\":{\"gpu\":false,\"solver\":{\"iterations\":" + iterations_n20 + ",\"test_interval\":200,\"base_lr\":0.01,\"snapshot\":2000,\"test_initialization\":true},\"net\":{\"batch_size\":100}},\"output\":{\"measure\":[\"acc\",\"mcll\",\"f1\",\"cmdiag\"]}},\"data\":[\"" + n20_repo + "news20\"]}";
+  joutstr = japi.jrender(japi.service_train(jtrainstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  JDoc jd;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(201,jd["status"]["code"].GetInt());
+  ASSERT_EQ("Created",jd["status"]["msg"]);
+  ASSERT_TRUE(jd.HasMember("head"));
+  ASSERT_EQ("/train",jd["head"]["method"]);
+  ASSERT_TRUE(jd["head"]["time"].GetDouble() >= 0);
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("train_loss"));
+  ASSERT_TRUE(fabs(jd["body"]["measure"]["train_loss"].GetDouble()) > 0);
+  ASSERT_TRUE(jd["body"]["measure"].HasMember("f1"));
+  ASSERT_TRUE(jd["body"]["measure"]["acc"].GetDouble() >= 0.5);
+  ASSERT_EQ(jd["body"]["measure"]["accp"].GetDouble(),jd["body"]["measure"]["acc"].GetDouble());
+
+  // predict with measure
+  std::string jpredictstr = "{\"service\":\"" + sname + "\",\"parameters\":{\"mllib\":{\"gpu\":false,\"net\":{\"test_batch_size\":10}},\"output\":{\"measure\":[\"f1\"]}},\"data\":[\"" + n20_repo +"news20\"]}";
+  joutstr = japi.jrender(japi.service_predict(jpredictstr));
+  std::cout << "joutstr=" << joutstr << std::endl;
+  jd.Parse(joutstr.c_str());
+  ASSERT_TRUE(!jd.HasParseError());
+  ASSERT_TRUE(jd.HasMember("status"));
+  ASSERT_EQ(200,jd["status"]["code"].GetInt());
+  ASSERT_TRUE(jd.HasMember("body"));
+  ASSERT_TRUE(jd["body"].HasMember("measure"));
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() >= 0.6);
+  ASSERT_TRUE(jd["body"]["measure"]["f1"].GetDouble() <= 1.0);
+
+  // remove service
+  jstr = "{\"clear\":\"full\"}";
+  joutstr = japi.jrender(japi.service_delete(sname,jstr));
+  ASSERT_EQ(ok_str,joutstr);
+  rmdir(n20_repo_loc.c_str());
+}
+
 TEST(caffeapi,service_train_txt_char)
 {
   // create service


### PR DESCRIPTION
Neural embeddings have proved useful for a variety of tasks, such as text classification. However, sparse representations such as one-hot vectors or bag of words (BOW) still yield better results in practice on a series of datasets. This has been carefully measured in practice by one of our partners and ourselves as well.

This PR brings support for sparse representation and computation, for CPU and GPU, to be used with the text input connectors, and other forthcoming connectors (see #112).

Sparse computations are realized by a custom version of Caffe, available from https://github.com/beniz/caffe/tree/master_dd_integ_sparse, more details in #8.

Current status:
- [x] Sparse computations on CPU
- [x] Sparse computations on GPU
- [x] Sparse `DataLayer` (LMDB / LevelDB)
- [x] Sparse `MemoryDataLayer`
- [x] Sparse `InnerProduct` layer
- [x] Support for text connector on BOW models
- [x] Generic libSVM format support for sparse data
- [x] No multi-target regression with sparse inputs since the matrix cannot be sliced at the moment 
- [x] Support for sparse logistic regression
- [x] Unit tests

Example:
Use `sparse:true` parameter to input `connector`.

This PR is sponsored by [ioSquare](http://iosquare.com/).