### PR TITLE
Imgsearch improvements

### DIFF
--- a/demo/imgsearch/README.md
+++ b/demo/imgsearch/README.md
@@ -45,6 +45,17 @@ To run the code on your own collection of images:
   ```
   Here `search-size` controls the number of approximate neighbors.
 
+
+### Running with a dockerised image
+
+- Start your docker container instance as per https://github.com/beniz/deepdetect/tree/master/docker but mount your images to a volume
+
+  `docker run -d -p 8080:8080 -v /full/path/to/your/images:/images beniz/deepdetect_cpu`
+ 
+  There is an additional `--model_repo` argument to specify the path to the model, this is relative to the volume mount in the docker container.
+  `--model_repo /model` with the additional argument on `docker run` of `-v /path/to/your/model:/model`
+
+
 Notes:
 
 - The search uses a deep convolutional net layer as a code for every image. Using top layers (e.g. `loss3/classifier` with GoogleNet) uses high level features and thus image similarity is based on high level concepts such as whether the image contains a lakeshore, a bottle, etc... Using bottom or mid-range layers (e.g. `pool5/7x7_s1` with GoogleNet) makes image similarity based on lower level, potentially invariant, universal features such as lightning conditions, basic shapes, etc... Experiment and see what is best for your application.

--- a/demo/imgsearch/imgsearch.py
+++ b/demo/imgsearch/imgsearch.py
@@ -54,7 +54,7 @@ parameters_mllib = {'nclasses':nclasses}
 
 template_name = 'googlenet'
 if not os.path.isfile(model_repo + '/' + template_name + '.prototxt'):
-    parameters_mllib['template'] = 'googlenet'
+    parameters_mllib['template'] = template_name
 
 parameters_output = {}
 dd.put_service(sname,model,description,mllib,

--- a/demo/imgsearch/imgsearch.py
+++ b/demo/imgsearch/imgsearch.py
@@ -12,6 +12,8 @@ parser.add_argument("--index",help="repository of images to be indexed")
 parser.add_argument("--index-batch-size",type=int,help="size of image batch when indexing",default=1)
 parser.add_argument("--search",help="image input file for similarity search")
 parser.add_argument("--search-size",help="number of nearest neighbors",type=int,default=10)
+parser.add_argument("--model_repo",help="path to model",default=os.getcwd() + '/model')
+
 args = parser.parse_args()
 
 def batch(iterable, n=1):
@@ -43,10 +45,12 @@ ntrees = 100
 metric = 'angular'  # or 'euclidean'
 
 # creating ML service
-model_repo = os.getcwd() + '/model'
+model_repo = args.model_repo
+
 model = {'repository':model_repo,'templates':'../templates/caffe/'}
 parameters_input = {'connector':'image','width':width,'height':height}
-parameters_mllib = {'nclasses':nclasses,'template':'googlenet'}
+#parameters_mllib = {'nclasses':nclasses,'template':'googlenet'}
+parameters_mllib = {'nclasses':nclasses}
 parameters_output = {}
 dd.put_service(sname,model,description,mllib,
                parameters_input,parameters_mllib,parameters_output,mltype)
@@ -97,7 +101,7 @@ if args.search:
     u.load('index.ann')
     data = [args.search]
     classif = dd.post_predict(sname,data,parameters_input,parameters_mllib,parameters_output)
-    near = u.get_nns_by_vector(classif['body']['predictions']['vals'],args.search_size,include_distances=True)
+    near = u.get_nns_by_vector(classif['body']['predictions'][0]['vals'],args.search_size,include_distances=True)
     print near
     near_names = []
     for n in near[0]:

--- a/demo/imgsearch/imgsearch.py
+++ b/demo/imgsearch/imgsearch.py
@@ -49,8 +49,13 @@ model_repo = args.model_repo
 
 model = {'repository':model_repo,'templates':'../templates/caffe/'}
 parameters_input = {'connector':'image','width':width,'height':height}
-#parameters_mllib = {'nclasses':nclasses,'template':'googlenet'}
+
 parameters_mllib = {'nclasses':nclasses}
+
+template_name = 'googlenet'
+if not os.path.isfile(model_repo + '/' + template_name + '.prototxt'):
+    parameters_mllib['template'] = 'googlenet'
+
 parameters_output = {}
 dd.put_service(sname,model,description,mllib,
                parameters_input,parameters_mllib,parameters_output,mltype)

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -12,6 +12,8 @@ RUN useradd -ms /bin/bash dd
 
 RUN apt-get update && apt-get install -y git cmake build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libcppnetlib-dev libboost-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev wget
 
+RUN apt-get install libboost-iostreams-dev -y
+
 WORKDIR /opt
 RUN git clone https://github.com/beniz/deepdetect.git && cd deepdetect && mkdir build
 
@@ -32,6 +34,9 @@ RUN cp /opt/deepdetect/datasets/imagenet/corresp_ilsvrc12.txt /opt/models/ggnet/
 RUN cp /opt/deepdetect/datasets/imagenet/corresp_ilsvrc12.txt /opt/models/resnet_50/corresp.txt
 RUN cp /opt/deepdetect/templates/caffe/googlenet/*prototxt /opt/models/ggnet/
 RUN cp /opt/deepdetect/templates/caffe/resnet_50/*prototxt /opt/models/resnet_50/
+
+# include python-pip and pip annoy so we can use the demo script
+RUN apt-get install --no-install-recommends -y python-pip python-dev && pip install annoy
 
 # permissions
 RUN chown -R dd:dd /opt/deepdetect

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -34,6 +34,10 @@ RUN cp /opt/deepdetect/datasets/imagenet/corresp_ilsvrc12.txt /opt/models/resnet
 RUN cp /opt/deepdetect/templates/caffe/googlenet/*prototxt /opt/models/ggnet/
 RUN cp /opt/deepdetect/templates/caffe/resnet_50/*prototxt /opt/models/resnet_50/
 
+# include python-pip and pip annoy so we can use the demo script
+RUN apt-get install --no-install-recommends -y python-pip python-dev && pip install annoy
+
+
 # permissions
 RUN chown -R dd:dd /opt/deepdetect
 RUN chown -R dd:dd /opt/models


### PR DESCRIPTION
Adds a little helpful tweak to the model-repo path of the imgsearch.py script (perhaps should be added to imgdetect.py in the future) and some clarification on the use of docker in README.md

The tweak to imgdetect.py `--model_repo` argument is so you can pass a different path altogether to the os.getpath() which is relative to the host not the container.

also added small fix which I'm not certain about...

`23:06 $ python imgsearch.py --search /images/a.jpg  --model_repo=/opt/models/ggnet
Traceback (most recent call last):
  File "imgsearch.py", line 104, in <module>
    near = u.get_nns_by_vector(classif['body']['predictions']['vals'],args.search_size,include_distances=True)
TypeError: list indices must be integers, not str`

The fix was

```
-    near = u.get_nns_by_vector(classif['body']['predictions']['vals'],args.search_size,include_distances=True)
+    near = u.get_nns_by_vector(classif['body']['predictions'][0]['vals'],args.search_size,include_distances=True)
```
