### PR TITLE
adding support for multiple GPUs for Caffe via API, ref #179

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ ExternalProject_Add(
   endif()
   if (CUDA_FOUND)
     set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src ${CUDA_INCLUDE_DIRS})
-    set(CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src /usr/lib/x86_64-linux-gnu/hdf5/serial ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES} ${CUDA_curand_LIBRARY})
+    set(CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src /usr/lib/x86_64-linux-gnu/hdf5/serial)
   else()
     set(CAFFE_INC_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/include ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src /usr/include/hdf5/serial)
     set(CAFFE_LIB_DIR ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/lib ${CMAKE_BINARY_DIR}/caffe_dd/src/caffe_dd/build/src /usr/lib/x86_64-linux-gnu/hdf5/serial)

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -1,6 +1,6 @@
 # Known NVIDIA GPU achitectures deepdetect can be compiled for.
 # This list will be used for CUDA_ARCH_NAME = All option
-set(deepdetect_known_gpu_archs "20 21(20) 30 35 50")
+set(deepdetect_known_gpu_archs "20 21(20) 30 35 50 61")
 
 ################################################################################################
 # A function for automatic detection of GPUs installed  (if autodetection is enabled)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,8 +1,9 @@
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${CAFFE_LIB_DIR} ${XGBOOST_LIB_DIR})
 if (CUDA_FOUND)
-  set(CUDA_LIB_DEPS -lcudart -lcublas -lcurand)# -lcudnn) #TODO: cudnn
+  set(CUDA_LIB_DEPS ${CUDA_LIBRARIES})
 else()
+  set(CUDA_LIB_DEPS "")
   add_definitions(-DCPU_ONLY)
 endif()
 set(CAFFE_LIB_DEPS -lleveldb -lsnappy -llmdb -lhdf5_hl -lhdf5 -lopenblas -lcaffe -lprotobuf)
@@ -13,4 +14,4 @@ else()
 endif()
   
 add_executable (dede dede.cc)
-target_link_libraries (dede ddetect glog gflags ${OpenCV_LIBS} cppnetlib-uri curlpp curl crypto ssl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
+target_link_libraries (dede ddetect ${CUDA_LIB_DEPS} glog gflags ${OpenCV_LIBS} cppnetlib-uri curlpp curl crypto ssl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -65,6 +65,37 @@ namespace dd
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::set_gpuid(const APIData &ad)
+  {
+#ifndef CPU_ONLY
+    if (ad.has("gpuid"))
+      {
+	try
+	  {
+	    int gpuid = ad.get("gpuid").get<int>();
+	    _gpuid = {gpuid};
+	    _gpu = true;
+	  }
+	catch(std::exception &e)
+	  {
+	    std::vector<int> gpuid = ad.get("gpuid").get<std::vector<int>>();
+	    if (gpuid.size()== 1 && gpuid.at(0) == -1)
+	      {
+		int count_gpus = 0;
+		cudaGetDeviceCount(&count_gpus);
+		for (int i =0;i<count_gpus;i++)
+		  _gpuid.push_back(i);
+	      }
+	    else _gpuid = gpuid;
+	    _gpu = true;
+	  }
+	for (auto i: _gpuid)
+	  LOG(INFO) << "Using GPU " << i << std::endl;
+      }
+#endif
+  }
+  
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
   void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::instantiate_template(const APIData &ad)
   {
     // - check whether there's a risk of erasing model files
@@ -1368,11 +1399,7 @@ namespace dd
   {
     if (ad.has("gpu"))
       _gpu = ad.get("gpu").get<bool>();
-    if (ad.has("gpuid"))
-      {
-	_gpuid = ad.get("gpuid").get<int>();
-	_gpu = true;
-      }
+    set_gpuid(ad);
     if (ad.has("nclasses"))
       _nclasses = ad.get("nclasses").get<int>();
     if (ad.has("regression") && ad.get("regression").get<bool>())
@@ -1452,27 +1479,26 @@ namespace dd
 
     // parameters
     APIData ad_mllib = ad.getobj("parameters").getobj("mllib");
+    bool gpu = _gpu;
 #ifndef CPU_ONLY
     if (ad_mllib.has("gpu"))
       {
-	bool gpu = ad_mllib.get("gpu").get<bool>();
+	gpu = ad_mllib.get("gpu").get<bool>();
 	if (gpu)
 	  {
-	    if (ad_mllib.has("gpuid"))
-	      Caffe::SetDevice(ad_mllib.get("gpuid").get<int>());
-	    Caffe::set_mode(Caffe::GPU);
+	    set_gpuid(ad_mllib);
 	  }
-	else Caffe::set_mode(Caffe::CPU);
       }
-    else
+    if (gpu)
       {
-	if (_gpu)
+	for (auto i: _gpuid)
 	  {
-	    Caffe::SetDevice(_gpuid);
-	    Caffe::set_mode(Caffe::GPU);
+	    Caffe::SetDevice(i);
+	    Caffe::DeviceQuery();
 	  }
-	else Caffe::set_mode(Caffe::CPU);
+	Caffe::set_mode(Caffe::GPU);
       }
+    else Caffe::set_mode(Caffe::CPU);
 #else
     Caffe::set_mode(Caffe::CPU);
 #endif
@@ -1985,26 +2011,25 @@ namespace dd
 
     // parameters
 #ifndef CPU_ONLY
+    bool gpu = _gpu;
     if (ad_mllib.has("gpu"))
       {
-	bool gpu = ad_mllib.get("gpu").get<bool>();
+	gpu = ad_mllib.get("gpu").get<bool>();
 	if (gpu)
 	  {
-	    if (ad_mllib.has("gpuid"))
-	      Caffe::SetDevice(ad_mllib.get("gpuid").get<int>());
-	    Caffe::set_mode(Caffe::GPU);
+	    set_gpuid(ad_mllib);
 	  }
-	else Caffe::set_mode(Caffe::CPU);       
       }
-    else
+    if (gpu)
       {
-	if (_gpu)
+	for (auto i: _gpuid)
 	  {
-	    Caffe::SetDevice(_gpuid);
-	    Caffe::set_mode(Caffe::GPU);
+	    Caffe::SetDevice(i);
+	    Caffe::DeviceQuery();
 	  }
-	else Caffe::set_mode(Caffe::CPU);
+	Caffe::set_mode(Caffe::GPU);
       }
+    else Caffe::set_mode(Caffe::CPU);
 #else
       Caffe::set_mode(Caffe::CPU);
 #endif

--- a/src/caffelib.h
+++ b/src/caffelib.h
@@ -196,11 +196,13 @@ namespace dd
 			  int &batch_size,
 			  int &test_batch_size,
 			  int &test_iter);
+
+      void set_gpuid(const APIData &ad);
       
     public:
       caffe::Net<float> *_net = nullptr; /**< neural net. */
       bool _gpu = false; /**< whether to use GPU. */
-      int _gpuid = 0; /**< GPU id. */
+      std::vector<int> _gpuid = {0}; /**< GPU id. */
       int _nclasses = 0; /**< required, as difficult to acquire from Caffe's internals. */
       bool _regression = false; /**< whether the net acts as a regressor. */
       int _ntargets = 0; /**< number of classification or regression targets. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 include_directories(${Boost_INCLUDE_DIRS})
 if (CUDA_FOUND)
-  set(CUDA_LIB_DEPS -lcudart -lcublas -lcurand)# -lcudnn)
+  set(CUDA_LIB_DEPS ${CUDA_LIBRARIES})
 else()
+  set(CUDA_LIB_DEPS "")
   add_definitions(-DCPU_ONLY)
 endif()
 set(CAFFE_LIB_DEPS -lleveldb -lsnappy -llmdb -lhdf5_hl -lhdf5 -lopenblas -lcaffe -lprotobuf)
@@ -16,21 +17,21 @@ find_package(GTest)
 include_directories(${GTEST_INCLUDE_DIRS})
 if (GTEST_FOUND)
   add_executable(ut_apidata ut-apidata.cc)
-  target_link_libraries(ut_apidata ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
+  target_link_libraries(ut_apidata ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
   add_test(
     NAME ut_apidata
     COMMAND ut_apidata
     )
   
   add_executable(ut_conn ut-conn.cc)
-  target_link_libraries(ut_conn ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
+  target_link_libraries(ut_conn ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
   add_test(
     NAME ut_conn
     COMMAND ut_conn
     )
   
   add_executable(ut_jsonapi ut-jsonapi.cc)
-  target_link_libraries(ut_jsonapi ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
+  target_link_libraries(ut_jsonapi ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
   add_test(
     NAME ut_jsonapi
     COMMAND ut_jsonapi
@@ -40,7 +41,7 @@ if (GTEST_FOUND)
   target_link_libraries(test_server boost_thread cppnetlib-uri cppnetlib-client-connections boost_system crypto ssl)
 
   add_executable(ut_caffe_mlp ut-caffe-mlp.cc)
-  target_link_libraries(ut_caffe_mlp ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
+  target_link_libraries(ut_caffe_mlp ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS} ${XGBOOST_LIB_DEPS})
   add_test(
     NAME ut_caffe_mlp
     COMMAND ut_caffe_mlp
@@ -99,14 +100,14 @@ if (GTEST_FOUND)
   endif()
   
   add_executable(ut_caffeapi ut-caffeapi.cc)
-  target_link_libraries(ut_caffeapi ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS}  ${XGBOOST_LIB_DEPS})
+  target_link_libraries(ut_caffeapi ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS}  ${XGBOOST_LIB_DEPS})
   add_test(
     NAME ut_caffeapi
     COMMAND ut_caffeapi
     )
   
   add_executable(ut_httpapi ut-httpapi.cc)
-  target_link_libraries(ut_httpapi ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS}  ${XGBOOST_LIB_DEPS} cppnetlib-uri curlpp curl crypto ssl)
+  target_link_libraries(ut_httpapi ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS}  ${XGBOOST_LIB_DEPS} cppnetlib-uri curlpp curl crypto ssl)
   add_test(
     NAME ut_httpapi
     COMMAND ut_httpapi
@@ -114,7 +115,7 @@ if (GTEST_FOUND)
 
 if (USE_XGBOOST)
   add_executable(ut_xgbapi ut-xgbapi.cc)
-  target_link_libraries(ut_xgbapi ddetect glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS}  ${XGBOOST_LIB_DEPS})
+  target_link_libraries(ut_xgbapi ddetect ${CUDA_LIB_DEPS} glog gflags gtest gtest_main ${OpenCV_LIBS} curlpp curl ${Boost_LIBRARIES} ${CAFFE_LIB_DEPS}  ${XGBOOST_LIB_DEPS})
   add_test(
     NAME ut_xgbapi
     COMMAND ut_xgbapi


### PR DESCRIPTION
This PR adds support for multiple GPUs with Caffe as requested by #179.
The following range of API `gpuid` parameter types and values are supported:

- single value, e.g. `gpuid:0` or `gpuid:1`
- special `gpuid:-1` value to specify that all GPUs should be used
- any combination in an array, e.g. `gpuid:[1,3]` to use two GPUs among many for instance