### PR TITLE
Support for Matthews correlation coefficient for binary classes problems

### DIFF
--- a/tests/ut-conn.cc
+++ b/tests/ut-conn.cc
@@ -101,7 +101,31 @@ TEST(outputconn,auc)
   SupervisedOutput so;
   double auc = so.auc(res_ad);
   ASSERT_EQ(0.75,auc);
-  }
+}
+
+TEST(outputconn,mcc)
+{
+  std::vector<double> targets = {0, 0, 1, 1};
+  std::vector<double> pred1 = {0.9, 0.1};
+  std::vector<double> pred2 = {0.6, 0.4};
+  std::vector<double> pred3 = {0.65, 0.35};
+  std::vector<double> pred4 = {0.2, 0.8};
+  std::vector<std::vector<double>> preds = { pred1, pred2, pred3, pred4 };
+  APIData res_ad;
+  res_ad.add("nclasses",2);
+  res_ad.add("batch_size",static_cast<int>(targets.size()));
+  for (size_t i=0;i<targets.size();i++)
+    {
+      APIData bad;
+      bad.add("pred",preds.at(i));
+      bad.add("target",targets.at(i));
+      std::vector<APIData> vad = {bad};
+      res_ad.add(std::to_string(i),vad);
+    }
+  SupervisedOutput so;
+  double mcc = so.mcc(res_ad);
+  ASSERT_EQ(0.57735,mcc);
+}
 
 TEST(outputconn,gini)
 {


### PR DESCRIPTION
Support for MCC, see https://en.wikipedia.org/wiki/Matthews_correlation_coefficient

Usages:
* binary classes problems
* use `mcc` in `measures` in API

Advantages:
* robust when classes are highly imbalanced
* can be used as test accuracy along `auc` and `f1