### PR TITLE
Prediction auto-sizing of batches, ref #129

### DIFF
--- a/src/caffeinputconns.cc
+++ b/src/caffeinputconns.cc
@@ -307,7 +307,7 @@ namespace dd
     return 0;
   }
 
-  std::vector<caffe::Datum> ImgCaffeInputFileConn::get_dv_test(const int &num,
+  std::vector<caffe::Datum> ImgCaffeInputFileConn::get_dv_test_db(const int &num,
 							       const bool &has_mean_file)
   {
     static Blob<float> data_mean;
@@ -369,6 +369,7 @@ namespace dd
   
   void ImgCaffeInputFileConn::reset_dv_test()
   {
+    _dt_vit = _dv_test.begin();
     _test_db_cursor = std::unique_ptr<caffe::db::Cursor>();
     _test_db = std::unique_ptr<caffe::db::DB>();
   }

--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -83,7 +83,10 @@ namespace dd
   {
   public:
     ImgCaffeInputFileConn()
-      :ImgInputFileConn() { _db = true; }
+      :ImgInputFileConn() {
+      _db = true;
+      reset_dv_test();
+    }
     ImgCaffeInputFileConn(const ImgCaffeInputFileConn &i)
       :ImgInputFileConn(i),CaffeInputInterface(i) { _db = true; }
     ~ImgCaffeInputFileConn() {}
@@ -220,7 +223,26 @@ namespace dd
     }
 
     std::vector<caffe::Datum> get_dv_test(const int &num,
-					  const bool &has_mean_file);
+					  const bool &has_mean_file)
+      {
+	if (!_train)
+	  {
+	    int i = 0;
+	    std::vector<caffe::Datum> dv;
+	    while(_dt_vit!=_dv_test.end()
+		  && i < num)
+	      {
+		dv.push_back((*_dt_vit));
+		++i;
+		++_dt_vit;
+	      }
+	    return dv;
+	  }
+	else return get_dv_test_db(num,has_mean_file);
+      }
+    
+    std::vector<caffe::Datum> get_dv_test_db(const int &num,
+					     const bool &has_mean_file);
 
     void reset_dv_test();
     
@@ -254,6 +276,7 @@ namespace dd
     std::string _meanfname = "mean.binaryproto";
     std::string _correspname = "corresp.txt";
     caffe::Blob<float> _data_mean; // mean binary image if available.
+    std::vector<caffe::Datum>::const_iterator _dt_vit;
   };
 
   /**


### PR DESCRIPTION
This PR brings the ability to `POST /predict` to size the batches according to `mllib.net.test_batch_size`. This means that `predict` now supports running over more data than there's memory available for either in RAM or on GPU.

Note that the batch size must still be specified via `test_batch_size` and it must be such that data fit the available memory for this batch size.

Examples of predicting over 3 images with `test_batch_size` of 2:
```
curl -X POST 'http://localhost:8080/predict' -d '{"service":"places","parameters":{"input":{"width":224,"height":224},"mllib":{"net":{"test_batch_size":2}},"output":{"best":3}},"data":["http://www.orelle.net/images/fr/station-orelle-montagne-savoie-ete.jpg","http://www.tortugamundi-voyages.com/wp-content/uploads/2012/03/Haute_Falaise_3-062-Copier.jpg","http://www.protrails.com/protrails/galleries/Death%20Valley%20-%20racetrack%20wide%20view.jpg"]}'
```