### PR TITLE
Added support for `class_weights` and special Softmax loss class for Caffe with weights

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/class_weights.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -82,7 +82,7 @@ ExternalProject_Add(
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/class_weights.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -93,7 +93,7 @@ ExternalProject_Add(
       caffe_dd
       PREFIX caffe_dd
       INSTALL_DIR ${CMAKE_BINARY_DIR}
-      URL https://github.com/beniz/caffe/archive/master.tar.gz
+      URL https://github.com/beniz/caffe/archive/class_weights.tar.gz
       CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
       INSTALL_COMMAND ""
       BUILD_IN_SOURCE 1

--- a/src/caffeinputconns.cc
+++ b/src/caffeinputconns.cc
@@ -32,6 +32,33 @@ using namespace caffe;
 
 namespace dd
 {
+
+  void CaffeInputInterface::write_class_weights(const std::string &model_repo,
+						const APIData &ad_mllib)
+  {
+    std::string cl_file = model_repo + "/class_weights.binaryproto";
+    if (ad_mllib.has("class_weights"))
+      {
+	std::vector<double> cw = ad_mllib.get("class_weights").get<std::vector<double>>();
+	int nclasses = cw.size();
+	BlobProto cw_blob;
+	cw_blob.set_num(1);
+	cw_blob.set_channels(1);
+	cw_blob.set_height(nclasses);
+	cw_blob.set_width(nclasses);
+	for (int i=0;i<nclasses;i++)
+	  {
+	    for (int j=0;j<nclasses;j++)
+	      {
+		if (i == j)
+		  cw_blob.add_data(cw.at(i));
+		else cw_blob.add_data(0.);
+	      }
+	  }
+	LOG(INFO) << "Write class weights to " << cl_file;
+	WriteProtoToBinaryFile(cw_blob,cl_file.c_str());
+      }
+  }
   
   // convert images into db entries
   // a root folder must contain directories as classes holding image

--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -1,6 +1,6 @@
 /**
  * DeepDetect
- * Copyright (c) 2014-2015 Emmanuel Benazera
+ * Copyright (c) 2014-2016 Emmanuel Benazera
  * Author: Emmanuel Benazera <beniz@droidnik.fr>
  *
  * This file is part of deepdetect.
@@ -64,6 +64,10 @@ namespace dd
       }
 
     void reset_dv_test() {}
+
+    // write class weights to binary proto
+    void write_class_weights(const std::string &model_repo,
+			     const APIData &ad_mllib);
 
     bool _db = false; /**< whether to use a db. */
     std::vector<caffe::Datum> _dv; /**< main input datum vector, used for training or prediction */
@@ -898,6 +902,7 @@ namespace dd
     {
       APIData ad_param = ad.getobj("parameters");
       APIData ad_input = ad_param.getobj("input");
+      APIData ad_mllib = ad_param.getobj("mllib");
       
       if (_train && ad_input.has("db") && ad_input.get("db").get<bool>())
 	{
@@ -905,6 +910,7 @@ namespace dd
 	  get_data(ad);
 	  _db = true;
 	  svm_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname,ad_input);
+	  write_class_weights(_model_repo,ad_mllib);
 	  
 	  // enrich data object with db files location
 	  APIData dbad;
@@ -927,6 +933,7 @@ namespace dd
 	
 	  if (_train)
 	    {
+	      write_class_weights(_model_repo,ad_mllib);
 	      int n = 0;
 	      auto hit = _svmdata.begin();
 	      while(hit!=_svmdata.end())

--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -200,6 +200,7 @@ namespace dd
 		throw ex;*/
 	      return;
 	    }
+	  APIData ad_mllib;
 	  if (ad.has("parameters")) // hotplug of parameters, overriding the defaults
 	    {
 	      APIData ad_param = ad.getobj("parameters");
@@ -207,6 +208,7 @@ namespace dd
 		{
 		  fillup_parameters(ad_param.getobj("input"));
 		}
+	      ad_mllib = ad_param.getobj("mllib");
 	    }
 	  
 	  // create db
@@ -216,6 +218,9 @@ namespace dd
 	  compute_images_mean(_model_repo + "/" + _dbname,
 			      _model_repo + "/" + _meanfname);
 
+	  // class weights if any
+	  write_class_weights(_model_repo,ad_mllib);
+	  
 	  // enrich data object with db files location
 	  APIData dbad;
 	  dbad.add("train_db",_model_repo + "/" + _dbfullname);
@@ -364,6 +369,7 @@ namespace dd
     {
       APIData ad_param = ad.getobj("parameters");
       APIData ad_input = ad_param.getobj("input");
+      APIData ad_mllib = ad_param.getobj("mllib");
       
       if (_train && ad_input.has("db") && ad_input.get("db").get<bool>())
 	{
@@ -372,6 +378,7 @@ namespace dd
 	  _db = true;
 	  csv_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname,
 		    ad_input);
+	  write_class_weights(_model_repo,ad_mllib);
 	  
 	  // enrich data object with db files location
 	  APIData dbad;
@@ -617,6 +624,7 @@ namespace dd
     {
       APIData ad_param = ad.getobj("parameters");
       APIData ad_input = ad_param.getobj("input");
+      APIData ad_mllib = ad_param.getobj("mllib");
       if (ad_input.has("db") && ad_input.get("db").get<bool>())
 	_db = true;
       
@@ -628,6 +636,8 @@ namespace dd
 	    TxtInputFileConn::transform(ad);
 	  txt_to_db(_model_repo + "/" + _dbname,_model_repo + "/" + _test_dbname,
 		    ad_input);
+	  write_class_weights(_model_repo,ad_mllib);
+
 	  
 	  // enrich data object with db files location
 	  APIData dbad;

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -2335,7 +2335,7 @@ namespace dd
 	  }
       }
 
-    if (has_class_weights) //TODO
+    if (has_class_weights)
       {
 	int k = net_param.layer_size();
 	for (int l=k-1;l>0;l--)

--- a/src/caffelib.h
+++ b/src/caffelib.h
@@ -180,10 +180,12 @@ namespace dd
        *                 at service creation
        * @param deploy_file the deploy file, same remark as net_file
        * @param inputc the current input constructor that holds the training data
+       * @param has_class_weights whether training uses class weights
        */
       void update_protofile_net(const std::string &net_file,
 				const std::string &deploy_file,
-				const TInputConnectorStrategy &inputc);
+				const TInputConnectorStrategy &inputc,
+				const bool &has_class_weights);
 
     private:
       void update_protofile_classes(caffe::NetParameter &net_param);


### PR DESCRIPTION
Related to completion of #202.

Usage:
- in `POST /train` calls, use `class_weights:[1.0,0.1,...]` as an array of floats, within the `mllib` object.
