### PR TITLE
Reporting net's flops and number of parameters for Caffe models

### DIFF
--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1391,6 +1391,15 @@ namespace dd
 	    _net = nullptr;
 	    throw;
 	  }
+	try
+	  {
+	    model_complexity(_flops,_params);
+	  }
+	catch(std::exception &e)
+	  {
+	    // nets can be exotic, let's make sure we don't get killed here
+	    LOG(ERROR) << "failed computing net's complexity";
+	  }
 	return 0;
       }
     // net definition is missing
@@ -2613,6 +2622,40 @@ namespace dd
 	if (batch_size == 0)
 	  throw MLLibBadParamException("auto batch size set to zero: MemoryData input requires batch size to be a multiple of training set");
       }
+  }
+
+  template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
+  void CaffeLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>::model_complexity(long int &flops,
+											     long int &params)
+  {
+    for (size_t l=0;l<_net->layers().size();l++)
+      {
+	const boost::shared_ptr<caffe::Layer<float>> &layer = _net->layers().at(l);
+	std::string lname = layer->layer_param().name();
+	std::string ltype = layer->layer_param().type();
+	std::vector<boost::shared_ptr<Blob<float>>> blblobs = layer->blobs();
+	const std::vector<caffe::Blob<float>*> &tlblobs = _net->top_vecs().at(l);
+	//std::cerr << "lname=" << lname << " / bottom layer blobs size=" << blblobs.size() << std::endl;
+	if (blblobs.empty())
+	  continue;
+	long int lcount = blblobs.at(0)->count();
+	long int lflops = 0;
+	if (ltype == "Convolution")
+	  {
+	    int dwidth = tlblobs.at(0)->width();
+	    int dheight = tlblobs.at(0)->height();
+	    //std::cerr << "dwidth=" << dwidth << " / dheight=" << dheight << std::endl;
+	    lflops = lcount * dwidth * dheight;
+	  }
+	else
+	  {
+	    lflops = lcount;
+	  }
+	//std::cerr << "lname=" << lname << " / ltype=" << ltype << " / lflops=" << lflops << " / lcount=" << lcount << std::endl;
+	flops += lflops;
+	params += lcount;
+      }
+    LOG(INFO) << "Net total flops=" << flops << " / total params=" << params << std::endl;
   }
   
   template class CaffeLib<ImgCaffeInputFileConn,SupervisedOutput,CaffeModel>;

--- a/src/caffelib.h
+++ b/src/caffelib.h
@@ -200,6 +200,9 @@ namespace dd
 			  int &test_iter);
 
       void set_gpuid(const APIData &ad);
+
+      void model_complexity(long int &flops,
+			    long int &params);
       
     public:
       caffe::Net<float> *_net = nullptr; /**< neural net. */
@@ -210,6 +213,8 @@ namespace dd
       int _ntargets = 0; /**< number of classification or regression targets. */
       bool _autoencoder = false; /**< whether an autoencoder. */
       std::mutex _net_mutex; /**< mutex around net, e.g. no concurrent predict calls as net is not re-instantiated. Use batches instead. */
+      long int _flops = 0;  /**< model flops. */
+      long int _params = 0;  /**< number of parameters in the model. */
     };
 
 }


### PR DESCRIPTION
FLOPS and number of parameters are reported in the server logs. Next to be reported by the API.

Example on a `ResNet 50`:
```
I0214 17:58:42.416816 21937 caffelib.cc:2658] Net total flops=3858026368 / total params=25556032
```
i.e. 3.85B FLOPS and 25.5M parameters.