### PR TITLE
Use weights parameter to load already existing caffemodel

### DIFF
--- a/src/caffemodel.cc
+++ b/src/caffemodel.cc
@@ -39,6 +39,15 @@ namespace dd
       {
        	if (read_from_repository(ad.get("repository").get<std::string>()))
 	  throw MLLibBadParamException("error reading or listing Caffe models in repository " + _repo);
+        if (ad.has("weights"))
+          {
+            _weights = ad.get("weights").get<std::string>();
+            if (!fileops::file_exists(_weights))
+              {
+                LOG(ERROR) << "error reading caffemodel " << _weights << std::endl;
+                throw MLLibBadParamException( "error reading caffemodel " + _weights);
+              }
+          }      
       }
     else
       {


### PR DESCRIPTION
This feature allows to specify which caffemodel to use when there are several ones in the same model repository. It is related to the issue #330.
It uses a new parameter called `weights` inside the parameter `model`. 
Example:
INPUT
```
curl -X PUT "http://localhost:8082/services/test" -d "{\"mllib\":\"caffe\",\"description\":\"classification service\",\"type\":\"supervised\",\"parameters\":{\"input\":{\"connector\":\"svm\"},\"mllib\":{\"nclasses\":2}},\"model\":{\"repository\":\"/home/test/models/exp1\", \"weights\": \"/home/test/models/exp1/model_iter_240000.caffemodel\"}}"
```

OUTPUT
```
I0703 15:22:12.981254  3506 caffelib.cc:397] Using pre-trained weights from /home/test/models/exp1/model_iter_240000.caffemodel
```