### PR TITLE
Finetuning - using feature top name instead of top name

### DIFF
--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1637,7 +1637,7 @@ namespace dd
 	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
 	if (lparam->type() == "Convolution")
 	  {
-            ft_oldname = lparam->top(0);
+	    ft_oldname = lparam->top(0);
 	    ft_lname = lparam->name() + "_ftune";
 	    lparam->set_name(ft_lname);
 	    lparam->set_top(0,ft_lname);

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1637,7 +1637,7 @@ namespace dd
 	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
 	if (lparam->type() == "Convolution")
 	  {
-	    ft_oldname = lparam->name();
+            ft_oldname = lparam->top(0);
 	    ft_lname = lparam->name() + "_ftune";
 	    lparam->set_name(ft_lname);
 	    lparam->set_top(0,ft_lname);
@@ -1646,7 +1646,7 @@ namespace dd
 	  }
 	else if (lparam->type() == "InnerProduct")
 	  {
-	    ft_oldname = lparam->name();
+	    ft_oldname = lparam->top(0);
 	    ft_lname = lparam->name() + "_ftune";
 	    lparam->set_name(ft_lname);
 	    lparam->set_top(0,ft_lname);


### PR DESCRIPTION
`ft_oldname` is used to update layers after.
```
    // update relations from other layers
    for (int l=net_param.layer_size()-1;l>k;l--)
      {
	caffe::LayerParameter *lparam = net_param.mutable_layer(l);
	if (lparam->top(0) == ft_oldname)
	  lparam->set_top(0,ft_lname);
	if (lparam->bottom(0) == ft_oldname)
	  lparam->set_bottom(0,ft_lname);
}
```

However when the layer of the name is different than the first top the condition `if (lparam->bottom(0) == ft_oldname)` will never trigger. This small PR corrects that by using the first top name instead of the layer name.