### PR TITLE
SVM connector - appending 1 to the max number of features

### DIFF
--- a/src/svminputfileconn.h
+++ b/src/svminputfileconn.h
@@ -219,7 +219,7 @@ namespace dd
     int feature_size() const
     {
       // total number of indices
-      return _max_id;
+      return _max_id + 1;
     }
 
     // serialization of vocabulary


### PR DESCRIPTION
The maximum number of features (in LMDB) is obtained by taking the max_id of the SVM. However, as the SVM files contain the id 0 we should append the maximum number of features by 1.

Let us take a SVM with the `max_id` is equal to 1000. That means that he has 1001 indices. However when a training is launched we observed that the size of the dimension `channels` is equal to 1000 and not 1001. 