### PR TITLE
Catch error when svm line is empty

### DIFF
--- a/src/svminputfileconn.cc
+++ b/src/svminputfileconn.cc
@@ -106,6 +106,8 @@ namespace dd
 	    throw InputConnectorBadParamException("error reading SVM format line: " + content);
 	  }
       }
+      if (vals.empty())
+        throw InputConnectorBadParamException("Issue while reading svm example (index might be out of boundsi)");
   }
   
   void SVMInputFileConn::read_svm(const APIData &ad,


### PR DESCRIPTION
When doing aprediction on a SVM, indexes of SVM examples should be bounded. When and index is out of those bounds DD core dumps (see the #343)
This PR attempts to correct it by catching an error after reading an SVM line.
Basically it checks if after reading one line from SVM any value was added to the variable `vals`.
At this point in the code, if nothing was caught that means the SVM line seems correct however `vals` might be empty If the index is out of bounds (see line 96 of https://github.com/beniz/deepdetect/blob/master/src/svminputfileconn.cc). If the example has only indexes out of bounds `vals` will be empty and it makes DD core dumps. To avoid that, verifying if `vals` is not empty might be a solution.