### PR TITLE
Add template for VDCNN with 17 layers

### DIFF
--- a/templates/caffe/vdcnn_17/deploy.prototxt
+++ b/templates/caffe/vdcnn_17/deploy.prototxt
@@ -1,0 +1,628 @@
+name: "vdcnn_17"
+layer {
+  name: "input"
+  type: "MemoryData"
+  top: "data"
+  top: "label"
+  memory_data_param {
+    batch_size: 32
+    channels: 1
+    height: 1014 # sequence length
+    width: 1
+  }
+}
+layer {
+  name: "flatten_0"
+  type: "Flatten"
+  bottom: "data"
+  top: "data_flat"
+  flatten_param {
+    axis: 1
+    end_axis: -1
+  }
+}
+layer {
+  name: "embed_0"
+  type: "Embed"
+  bottom: "data_flat"
+  top: "data_emb"
+  param {
+   lr_mult: 1
+  }
+  embed_param {
+   bias_term: false
+   input_dim: 70 # alphabet size
+   num_output: 16
+   weight_filler {
+    type: "uniform"
+    min: -0.1
+    max: 0.1
+   }
+ }
+}
+layer {
+  name: "reshape_embed_0"
+  type: "Reshape"
+  bottom: "data_emb"
+  top: "data_emb_reshape"
+  reshape_param {
+   shape {
+     dim: 0
+     dim: 1
+     dim: 1014 # sequence length
+     dim: 16
+    }
+  }
+}
+layer {
+  name: "ip0_conv_0"
+  type: "Convolution"
+  bottom: "data_emb_reshape"
+  top: "ip0_conv_0"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 16
+  }
+}
+layer {
+  name: "ip1_conv_0"
+  type: "Convolution"
+  bottom: "ip0_conv_0"
+  top: "ip1_conv_0"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_0"
+  type: "ReLU"
+  bottom: "ip1_conv_0"
+  top: "ip1_conv_0"
+}
+layer {
+  name: "ip1_conv_1"
+  type: "Convolution"
+  bottom: "ip1_conv_0"
+  top: "ip1_conv_1"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_1"
+  type: "ReLU"
+  bottom: "ip1_conv_1"
+  top: "ip1_conv_1"
+}
+layer {
+  name: "ip1_conv_2"
+  type: "Convolution"
+  bottom: "ip1_conv_1"
+  top: "ip1_conv_2"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_2"
+  type: "ReLU"
+  bottom: "ip1_conv_2"
+  top: "ip1_conv_2"
+}
+layer {
+  name: "ip1_conv_3"
+  type: "Convolution"
+  bottom: "ip1_conv_2"
+  top: "ip1_conv_3"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_3"
+  type: "ReLU"
+  bottom: "ip1_conv_3"
+  top: "ip1_conv_3"
+}
+
+layer {
+  name: "pool_ip1_conv_3"
+  type: "Pooling"
+  bottom: "ip1_conv_3"
+  top: "ip1"
+  pooling_param {
+    pool: MAX
+    kernel_h: 3
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+    #pad_h: 1
+  }
+}
+layer {
+  name: "ip2_conv_0"
+  type: "Convolution"
+  bottom: "ip1"
+  top: "ip2_conv_0"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 2
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip2_conv_0"
+  type: "ReLU"
+  bottom: "ip2_conv_0"
+  top: "ip2_conv_0"
+}
+layer {
+  name: "ip2_conv_1"
+  type: "Convolution"
+  bottom: "ip2_conv_0"
+  top: "ip2_conv_1"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip2_conv_1"
+  type: "ReLU"
+  bottom: "ip2_conv_1"
+  top: "ip2_conv_1"
+}
+layer {
+  name: "ip2_conv_2"
+  type: "Convolution"
+  bottom: "ip2_conv_1"
+  top: "ip2_conv_2"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 2
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip2_conv_2"
+  type: "ReLU"
+  bottom: "ip2_conv_2"
+  top: "ip2_conv_2"
+}
+layer {
+  name: "ip2_conv_3"
+  type: "Convolution"
+  bottom: "ip2_conv_2"
+  top: "ip2_conv_3"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip2_conv_3"
+  type: "ReLU"
+  bottom: "ip2_conv_3"
+  top: "ip2_conv_3"
+}
+
+layer {
+  name: "pool_ip2_conv_3"
+  type: "Pooling"
+  bottom: "ip2_conv_3"
+  top: "ip2"
+  pooling_param {
+    pool: MAX
+    kernel_h: 3
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+    #pad_h: 1
+  }
+}
+layer {
+  name: "ip3_conv_0"
+  type: "Convolution"
+  bottom: "ip2"
+  top: "ip3_conv_0"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip3_conv_0"
+  type: "ReLU"
+  bottom: "ip3_conv_0"
+  top: "ip3_conv_0"
+}
+layer {
+  name: "ip3_conv_1"
+  type: "Convolution"
+  bottom: "ip3_conv_0"
+  top: "ip3_conv_1"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip3_conv_1"
+  type: "ReLU"
+  bottom: "ip3_conv_1"
+  top: "ip3_conv_1"
+}
+
+layer {
+  name: "ip3_conv_2"
+  type: "Convolution"
+  bottom: "ip3_conv_1"
+  top: "ip3_conv_2"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip3_conv_2"
+  type: "ReLU"
+  bottom: "ip3_conv_2"
+  top: "ip3_conv_2"
+}
+layer {
+  name: "ip3_conv_3"
+  type: "Convolution"
+  bottom: "ip3_conv_2"
+  top: "ip3_conv_3"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip3_conv_3"
+  type: "ReLU"
+  bottom: "ip3_conv_3"
+  top: "ip3_conv_3"
+}
+
+layer {
+  name: "pool_ip3_conv_3"
+  type: "Pooling"
+  bottom: "ip3_conv_3"
+  top: "ip3"
+  pooling_param {
+    pool: MAX
+    kernel_h: 3
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+    #pad_h: 1
+  }
+}
+layer {
+  name: "ip4_conv_0"
+  type: "Convolution"
+  bottom: "ip3"
+  top: "ip4_conv_0"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_0"
+  type: "ReLU"
+  bottom: "ip4_conv_0"
+  top: "ip4_conv_0"
+}
+layer {
+  name: "ip4_conv_1"
+  type: "Convolution"
+  bottom: "ip4_conv_0"
+  top: "ip4_conv_1"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_1"
+  type: "ReLU"
+  bottom: "ip4_conv_1"
+  top: "ip4_conv_1"
+}
+
+layer {
+  name: "ip4_conv_2"
+  type: "Convolution"
+  bottom: "ip4_conv_1"
+  top: "ip4_conv_2"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_2"
+  type: "ReLU"
+  bottom: "ip4_conv_2"
+  top: "ip4_conv_2"
+}
+layer {
+  name: "ip4_conv_3"
+  type: "Convolution"
+  bottom: "ip4_conv_2"
+  top: "ip4_conv_3"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_3"
+  type: "ReLU"
+  bottom: "ip4_conv_3"
+  top: "ip4_conv_3"
+}
+
+layer {
+  name: "pool_ip4_conv_3"
+  type: "Pooling"
+  bottom: "ip4_conv_3"
+  top: "ip4"
+  pooling_param {
+    pool: MAX
+    kernel_h: 8
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+  }
+}
+layer {
+  name: "reshape_reshape0"
+  type: "Reshape"
+  bottom: "ip4"
+  top: "reshape0"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: -1
+    }
+  }
+ }
+layer {
+  name: "fc_reshape0"
+  type: "InnerProduct"
+  bottom: "reshape0"
+  top: "fc4096_0"
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "act_ReLU_fc4096_0"
+  type: "ReLU"
+  bottom: "fc4096_0"
+  top: "fc4096_0"
+}
+layer {   
+  name: "drop_fc4096_0"
+  type: "Dropout"
+  bottom: "fc4096_0"
+  top: "fc4096_0" 
+  dropout_param {
+   dropout_ratio: 0.5  
+  }
+}
+layer {
+  name: "fc_fc4096_0"
+  type: "InnerProduct"
+  bottom: "fc4096_0"
+  top: "fc2048_1"
+  inner_product_param {
+    num_output: 2048
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "act_ReLU_fc2048_1"
+  type: "ReLU"
+  bottom: "fc2048_1"
+  top: "fc2048_1"
+}
+layer {   
+  name: "drop_fc2048_1"
+  type: "Dropout"
+  bottom: "fc2048_1"
+  top: "fc2048_1" 
+  dropout_param {
+   dropout_ratio: 0.5  
+  }
+}      
+layer {
+  name: "fc_fc2048_1"
+  type: "InnerProduct"
+  bottom: "fc2048_1"
+  top: "ip_losst"
+  inner_product_param {
+    num_output: 4 # number of classes
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "probt"
+  type: "Softmax"
+  bottom: "ip_losst"
+  top: "prob"
+}

--- a/templates/caffe/vdcnn_17/vdcnn_17.prototxt
+++ b/templates/caffe/vdcnn_17/vdcnn_17.prototxt
@@ -1,0 +1,658 @@
+name: "vdcnn_17"
+layer {
+  name: "inputl"
+  type: "Data"
+  top: "data"
+  top: "label"
+  include {
+    phase: TRAIN
+  }
+  data_param {
+    source: "train.lmdb"
+    batch_size: 32
+    backend: LMDB
+  }
+}
+layer {
+  name: "inputl"
+  type: "MemoryData"
+  top: "data"
+  top: "label"
+  include {
+    phase: TEST
+  }
+  memory_data_param {
+    batch_size: 32
+    channels: 1
+    height: 1014 # sequence length
+    width: 1
+  }
+}
+layer {
+  name: "flatten_0"
+  type: "Flatten"
+  bottom: "data"
+  top: "data_flat"
+  flatten_param {
+    axis: 1
+    end_axis: -1
+  }
+}
+layer {
+  name: "embed_0"
+  type: "Embed"
+  bottom: "data_flat"
+  top: "data_emb"
+  param {
+   lr_mult: 1
+  }
+  embed_param {
+   bias_term: false
+   input_dim: 70 # alphabet size
+   num_output: 16
+   weight_filler {
+    type: "uniform"
+    min: -0.1
+    max: 0.1
+   }
+ }
+}
+layer {
+  name: "reshape_embed_0"
+  type: "Reshape"
+  bottom: "data_emb"
+  top: "data_emb_reshape"
+  reshape_param {
+   shape {
+     dim: 0
+     dim: 1
+     dim: 1014 # sequence length
+     dim: 16
+    }
+  }
+}
+layer {
+  name: "ip0_conv_0"
+  type: "Convolution"
+  bottom: "data_emb_reshape"
+  top: "ip0_conv_0"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 16
+  }
+}
+layer {
+  name: "ip1_conv_0"
+  type: "Convolution"
+  bottom: "ip0_conv_0"
+  top: "ip1_conv_0"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_0"
+  type: "ReLU"
+  bottom: "ip1_conv_0"
+  top: "ip1_conv_0"
+}
+layer {
+  name: "ip1_conv_1"
+  type: "Convolution"
+  bottom: "ip1_conv_0"
+  top: "ip1_conv_1"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_1"
+  type: "ReLU"
+  bottom: "ip1_conv_1"
+  top: "ip1_conv_1"
+}
+layer {
+  name: "ip1_conv_2"
+  type: "Convolution"
+  bottom: "ip1_conv_1"
+  top: "ip1_conv_2"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_2"
+  type: "ReLU"
+  bottom: "ip1_conv_2"
+  top: "ip1_conv_2"
+}
+layer {
+  name: "ip1_conv_3"
+  type: "Convolution"
+  bottom: "ip1_conv_2"
+  top: "ip1_conv_3"
+  convolution_param {
+    num_output: 64
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip1_conv_3"
+  type: "ReLU"
+  bottom: "ip1_conv_3"
+  top: "ip1_conv_3"
+}
+
+layer {
+  name: "pool_ip1_conv_3"
+  type: "Pooling"
+  bottom: "ip1_conv_3"
+  top: "ip1"
+  pooling_param {
+    pool: MAX
+    kernel_h: 3
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+    #pad_h: 1
+  }
+}
+layer {
+  name: "ip2_conv_0"
+  type: "Convolution"
+  bottom: "ip1"
+  top: "ip2_conv_0"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 2
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip2_conv_0"
+  type: "ReLU"
+  bottom: "ip2_conv_0"
+  top: "ip2_conv_0"
+}
+layer {
+  name: "ip2_conv_1"
+  type: "Convolution"
+  bottom: "ip2_conv_0"
+  top: "ip2_conv_1"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip2_conv_1"
+  type: "ReLU"
+  bottom: "ip2_conv_1"
+  top: "ip2_conv_1"
+}
+layer {
+  name: "ip2_conv_2"
+  type: "Convolution"
+  bottom: "ip2_conv_1"
+  top: "ip2_conv_2"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 2
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip2_conv_2"
+  type: "ReLU"
+  bottom: "ip2_conv_2"
+  top: "ip2_conv_2"
+}
+layer {
+  name: "ip2_conv_3"
+  type: "Convolution"
+  bottom: "ip2_conv_2"
+  top: "ip2_conv_3"
+  convolution_param {
+    num_output: 128
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip2_conv_3"
+  type: "ReLU"
+  bottom: "ip2_conv_3"
+  top: "ip2_conv_3"
+}
+
+layer {
+  name: "pool_ip2_conv_3"
+  type: "Pooling"
+  bottom: "ip2_conv_3"
+  top: "ip2"
+  pooling_param {
+    pool: MAX
+    kernel_h: 3
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+    #pad_h: 1
+  }
+}
+layer {
+  name: "ip3_conv_0"
+  type: "Convolution"
+  bottom: "ip2"
+  top: "ip3_conv_0"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip3_conv_0"
+  type: "ReLU"
+  bottom: "ip3_conv_0"
+  top: "ip3_conv_0"
+}
+layer {
+  name: "ip3_conv_1"
+  type: "Convolution"
+  bottom: "ip3_conv_0"
+  top: "ip3_conv_1"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+layer {
+  name: "act_ReLU_ip3_conv_1"
+  type: "ReLU"
+  bottom: "ip3_conv_1"
+  top: "ip3_conv_1"
+}
+
+layer {
+  name: "ip3_conv_2"
+  type: "Convolution"
+  bottom: "ip3_conv_1"
+  top: "ip3_conv_2"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip3_conv_2"
+  type: "ReLU"
+  bottom: "ip3_conv_2"
+  top: "ip3_conv_2"
+}
+layer {
+  name: "ip3_conv_3"
+  type: "Convolution"
+  bottom: "ip3_conv_2"
+  top: "ip3_conv_3"
+  convolution_param {
+    num_output: 256
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip3_conv_3"
+  type: "ReLU"
+  bottom: "ip3_conv_3"
+  top: "ip3_conv_3"
+}
+
+layer {
+  name: "pool_ip3_conv_3"
+  type: "Pooling"
+  bottom: "ip3_conv_3"
+  top: "ip3"
+  pooling_param {
+    pool: MAX
+    kernel_h: 3
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+    #pad_h: 1
+  }
+}
+layer {
+  name: "ip4_conv_0"
+  type: "Convolution"
+  bottom: "ip3"
+  top: "ip4_conv_0"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_0"
+  type: "ReLU"
+  bottom: "ip4_conv_0"
+  top: "ip4_conv_0"
+}
+layer {
+  name: "ip4_conv_1"
+  type: "Convolution"
+  bottom: "ip4_conv_0"
+  top: "ip4_conv_1"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_1"
+  type: "ReLU"
+  bottom: "ip4_conv_1"
+  top: "ip4_conv_1"
+}
+
+layer {
+  name: "ip4_conv_2"
+  type: "Convolution"
+  bottom: "ip4_conv_1"
+  top: "ip4_conv_2"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_2"
+  type: "ReLU"
+  bottom: "ip4_conv_2"
+  top: "ip4_conv_2"
+}
+layer {
+  name: "ip4_conv_3"
+  type: "Convolution"
+  bottom: "ip4_conv_2"
+  top: "ip4_conv_3"
+  convolution_param {
+    num_output: 512
+    pad_h: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+    }
+    kernel_h: 3
+    kernel_w: 1
+  }
+}
+
+layer {
+  name: "act_ReLU_ip4_conv_3"
+  type: "ReLU"
+  bottom: "ip4_conv_3"
+  top: "ip4_conv_3"
+}
+
+layer {
+  name: "pool_ip4_conv_3"
+  type: "Pooling"
+  bottom: "ip4_conv_3"
+  top: "ip4"
+  pooling_param {
+    pool: MAX
+    kernel_h: 8
+    kernel_w: 1
+    stride_h: 2
+    stride_w: 1
+  }
+}
+layer {
+  name: "reshape_reshape0"
+  type: "Reshape"
+  bottom: "ip4"
+  top: "reshape0"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: -1
+    }
+  }
+ }
+layer {
+  name: "fc_reshape0"
+  type: "InnerProduct"
+  bottom: "reshape0"
+  top: "fc4096_0"
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "act_ReLU_fc4096_0"
+  type: "ReLU"
+  bottom: "fc4096_0"
+  top: "fc4096_0"
+}
+layer {   
+  name: "drop_fc4096_0"
+  type: "Dropout"
+  bottom: "fc4096_0"
+  top: "fc4096_0" 
+  dropout_param {
+   dropout_ratio: 0.5  
+  }
+}
+layer {
+  name: "fc_fc4096_0"
+  type: "InnerProduct"
+  bottom: "fc4096_0"
+  top: "fc2048_1"
+  inner_product_param {
+    num_output: 2048
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "act_ReLU_fc2048_1"
+  type: "ReLU"
+  bottom: "fc2048_1"
+  top: "fc2048_1"
+}
+layer {   
+  name: "drop_fc2048_1"
+  type: "Dropout"
+  bottom: "fc2048_1"
+  top: "fc2048_1" 
+  dropout_param {
+   dropout_ratio: 0.5  
+  }
+}      
+layer {
+  name: "fc_fc2048_1"
+  type: "InnerProduct"
+  bottom: "fc2048_1"
+  top: "ip_losst"
+  inner_product_param {
+    num_output: 4 # number of classes
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "prob"
+  type: "SoftmaxWithLoss"
+  bottom: "ip_losst"
+  bottom: "label"
+  top: "losst"
+  include {
+    phase: TRAIN
+  }
+}
+layer {
+  name: "probt"
+  type: "Softmax"
+  bottom: "ip_losst"
+  top: "losst"
+  include {
+    phase: TEST
+  }
+}

--- a/templates/caffe/vdcnn_17/vdcnn_17_solver.prototxt
+++ b/templates/caffe/vdcnn_17/vdcnn_17_solver.prototxt
@@ -1,0 +1,12 @@
+net: "vdcnn_17.prototxt"
+test_iter: 1000
+test_interval: 1000
+base_lr: 0.01
+lr_policy: "fixed"
+display: 100
+max_iter: 50000
+momentum: 0.9
+weight_decay: 0.0001
+snapshot: 10000
+snapshot_prefix: "vdcnn_17"
+solver_mode: GPU


### PR DESCRIPTION
Add VDCNN with 17 layers from https://arxiv.org/abs/1606.01781

- Service creation
`curl -X PUT 'http://localhost:8100/services/agnews' -d '{"mllib":"caffe","description":"agnews classifier","type":"supervised","parameters":{"input":{"connector":"txt","characters":true,"embedding":true,"sequence":1014},"mllib":{"nclasses":4,"template":"vdcnn_17"}},"model":{"templates":"../../templates/caffe/","repository":"/path/to/model"}}'
`

- Training
`curl -X POST 'http://localhost:8100/train' -d '{"service":"agnews","parameters":{"input":{"connector":"txt","embedding":true,"sentences":true,"db":true,"test_split":0.06,"shuffle":true},"mllib":{"gpu":true,"net":{"batch_size":128,"test_batch_size":128},"solver":{"test_interval":1000,"snpashot":1000,"base_lr":0.01,"solver_type":"ADAM","iterations":25000}},"output":{"measure":["mcll","f1","cmdiag","cmfull"]}},"data":["/path/to/agnews_data/"]}'
`

Here `agnews_data` contains one directory per class. Every directory contains a single `.txt` file with one text document per line. To use one file per document instead, set `sentences` to false.