### PR TITLE
Support for inference with connectionist temporal classification (CTC) with caffe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	  URL https://github.com/beniz/caffe/archive/master.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -165,7 +165,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	  URL https://github.com/beniz/caffe/archive/master.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn.jetson Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -175,7 +175,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	  URL https://github.com/beniz/caffe/archive/master.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -187,7 +187,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	  URL https://github.com/beniz/caffe/archive/master.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${TENSORFLOW_CC_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -197,7 +197,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	  URL https://github.com/beniz/caffe/archive/master.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -211,7 +211,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	URL https://github.com/beniz/caffe/archive/master.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -221,7 +221,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/ctc.tar.gz
+	URL https://github.com/beniz/caffe/archive/master.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -165,7 +165,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn.jetson Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -175,7 +175,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -187,7 +187,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${TENSORFLOW_CC_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -197,7 +197,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -211,7 +211,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -221,7 +221,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/ctc.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1498,7 +1498,6 @@ namespace dd
 	      int slot = results.size() - 1;
 	      const int alphabet_size = results[slot]->shape(2);
 	      const int time_step = results[slot]->shape(0);
-	      int scperel = results[slot]->count() / batch_size;
 	      const float *pred_data = results[slot]->cpu_data();
 	      for (int j=0;j<batch_size;j++)
 		{

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1125,6 +1125,8 @@ namespace dd
     APIData ad_output = ad.getobj("parameters").getobj("output");
     bool bbox = false;
     bool rois = false;
+    bool ctc = false;
+    int blank_label = -1;
     std::string roi_layer;
     double confidence_threshold = 0.0;
     if (ad_output.has("confidence_threshold"))
@@ -1145,6 +1147,12 @@ namespace dd
       roi_layer =  ad_output.get("rois").get<std::string>();
       rois = true;
     }
+    if (ad_output.has("ctc"))
+      {
+	ctc = ad_output.get("ctc").get<bool>();
+	if (ad_output.has("blank_label"))
+	  blank_label = ad_output.get("blank_label").get<int>();
+      }
 
     // gpu
 #if !defined(CPU_ONLY) && !defined(USE_CAFFE_CPU_ONLY)
@@ -1484,6 +1492,54 @@ namespace dd
 		vrad.push_back(rad);
 	      }
 	    }
+	    else if (ctc)
+	    {
+	      // input is time_step x batch_size x alphabet_size
+	      int slot = results.size() - 1;
+	      const int alphabet_size = results[slot]->shape(2);
+	      const int time_step = results[slot]->shape(0);
+	      int scperel = results[slot]->count() / batch_size;
+	      const float *pred_data = results[slot]->cpu_data();
+	      for (int j=0;j<batch_size;j++)
+		{
+		  std::vector<int> pred_label_seq_with_blank(time_step);
+		  std::vector<std::vector<float>> pred_sample;
+
+		  const float *pred_cur = pred_data;
+		  pred_cur += j*alphabet_size;
+		  for (int t=0;t<time_step;t++)
+		    {
+		      pred_label_seq_with_blank[t] = std::max_element(pred_cur, pred_cur + alphabet_size) - pred_cur;
+		      pred_cur += batch_size * alphabet_size;
+		    }
+
+		  // get labels seq
+		  std::vector<int> pred_label_seq;
+		  int prev = blank_label;
+		  for(int l = 0; l < time_step; ++l)
+		    {
+		      int cur = pred_label_seq_with_blank[l];
+		      if(cur != prev && cur != blank_label)
+			pred_label_seq.push_back(cur);
+		      prev = cur;
+		    }
+		  APIData outseq;
+		  std::string outstr;
+		  for (auto l: pred_label_seq)
+		    {
+		      outstr += this->_mlmodel.get_hcorresp(l);
+		    }
+		  std::vector<std::string> cats;
+		  cats.push_back(outstr);
+		  if (!inputc._ids.empty())
+		    outseq.add("uri",inputc._ids.at(idoffset+j));
+		  else outseq.add("uri",std::to_string(idoffset+j));
+		  outseq.add("cats",cats);
+		  outseq.add("probs",std::vector<double>(1,1.0)); //XXX: in raw pred_label_seq_with_blank
+		  outseq.add("loss",0.0);
+		  vrad.push_back(outseq);
+		}
+	    }
 	    else // classification
 	      {
 		int slot = results.size() - 1;
@@ -1584,6 +1640,7 @@ namespace dd
     out.add("nclasses",nclasses);
     out.add("bbox",bbox);
     out.add("roi",rois);
+    out.add("ctc",ctc);
     if (!inputc._segmentation)
       tout.finalize(ad.getobj("parameters").getobj("output"),out,static_cast<MLModel*>(&this->_mlmodel));
     else // segmentation returns an array, best dealt with an unsupervised connector

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -135,13 +135,13 @@ namespace dd
 	  std::vector<double> probs = ad.get("probs").get<std::vector<double>>();
 	  std::vector<std::string> cats = ad.get("cats").get<std::vector<std::string>>();
 	  std::vector<APIData> bboxes;
-      std::vector<APIData> rois;
+	  std::vector<APIData> rois;
 	  if (ad.has("bboxes"))
 	    bboxes = ad.getv("bboxes");
-      if (ad.has("vals")) {
-        rois = ad.getv("vals");
-      }
-      if ((hit=_vcats.find(uri))==_vcats.end())
+	  if (ad.has("vals")) {
+	    rois = ad.getv("vals");
+	  }
+	  if ((hit=_vcats.find(uri))==_vcats.end())
 	    {
 	      auto resit = _vcats.insert(std::pair<std::string,int>(uri,_vvcats.size()));
 	      _vvcats.push_back(sup_result(uri,loss));
@@ -151,7 +151,7 @@ namespace dd
 		  _vvcats.at((*hit).second).add_cat(probs.at(i),cats.at(i));
 		  if (!bboxes.empty())
 		    _vvcats.at((*hit).second).add_bbox(probs.at(i),bboxes.at(i));
-          if (!rois.empty())
+		  if (!rois.empty())
 		    _vvcats.at((*hit).second).add_val(probs.at(i),rois.at(i));
 		}
 	    }
@@ -284,6 +284,7 @@ namespace dd
 	}
       bool has_bbox = false;
       bool has_roi = false;
+      bool has_ctc = false;
       if (ad_out.has("bbox") && ad_out.get("bbox").get<bool>())
 	{
 	  has_bbox = true;
@@ -296,8 +297,12 @@ namespace dd
           has_roi = true;
         }
 
+      if (ad_out.has("ctc") && ad_out.get("ctc").get<bool>())
+	{
+	  has_ctc = true;
+	}
       best_cats(ad_in,bcats,nclasses,has_bbox,has_roi);
-
+      
       std::unordered_set<std::string> indexed_uris;
 #ifdef USE_SIMSEARCH
       // index
@@ -368,7 +373,7 @@ namespace dd
 	}
 #endif
 
-      bcats.to_ad(ad_out,regression,autoencoder,has_bbox,has_roi,indexed_uris);
+      bcats.to_ad(ad_out,regression,autoencoder,has_bbox,has_roi,has_ctc,indexed_uris);
     }
     
     struct PredictionAndAnswer {
@@ -837,7 +842,7 @@ namespace dd
      * @param indexed_uris list of indexed uris, if any
      */
     void to_ad(APIData &out, const bool &regression, const bool &autoencoder,
-	       const bool &has_bbox, const bool &has_roi,
+	       const bool &has_bbox, const bool &has_roi, const bool &has_ctc,
 	       const std::unordered_set<std::string> &indexed_uris) const
     {
       static std::string cl = "classes";
@@ -865,38 +870,38 @@ namespace dd
 	    {
 	      APIData nad;
 	      if (!autoencoder)
-            nad.add(chead,(*mit).second);
+		nad.add(chead,(*mit).second);
 	      if (regression)
-            nad.add(vhead,(*mit).first);
+		nad.add(vhead,(*mit).first);
 	      else if (autoencoder)
-            nad.add(ahead,(*mit).first);
+		nad.add(ahead,(*mit).first);
 	      else nad.add(phead,(*mit).first);
 	      if (has_bbox || has_roi)
-            {
-              nad.add(bb,(*bit).second);
-              ++bit;
-            }
-          if (has_roi)
-            {
-              /* std::vector<std::string> keys = (*vit).second.list_keys(); */
-              /* std::copy(keys.begin(), keys.end(), std::ostream_iterator<std::string>(std::cout, "'")); */
-              /* std::cout << std::endl; */
-              nad.add(roi,(*vit).second.get("vals").get<std::vector<double>>());
-              ++vit;
-            }
+		{
+		  nad.add(bb,(*bit).second);
+		  ++bit;
+		}
+	      if (has_roi)
+		{
+		  /* std::vector<std::string> keys = (*vit).second.list_keys(); */
+		  /* std::copy(keys.begin(), keys.end(), std::ostream_iterator<std::string>(std::cout, "'")); */
+		  /* std::cout << std::endl; */
+		  nad.add(roi,(*vit).second.get("vals").get<std::vector<double>>());
+		  ++vit;
+		}
 	      ++mit;
 	      if (mit == _vvcats.at(i)._cats.end())
-            nad.add(last,true);
+		nad.add(last,true);
 	      v.push_back(nad);
 	    }
 	  if (regression)
 	    adpred.add(ve,v);
 	  else if (autoencoder)
 	    adpred.add(ae,v);
-      else if (has_bbox)
-        adpred.add(bb, v);
-      else if (has_roi)
-        adpred.add(rois,v);
+	  else if (has_bbox)
+	    adpred.add(bb, v);
+	  else if (has_roi)
+	    adpred.add(rois,v);
 	  else adpred.add(cl,v);
 	  if (_vvcats.at(i)._loss > 0.0) // XXX: not set by Caffe in prediction mode for now
 	    adpred.add("loss",_vvcats.at(i)._loss);


### PR DESCRIPTION
Support for tasks such as:
- captcha reading
- speech to text
- machine translation
- image captioning

API update:
- `ctc:true` in `output` JSON object on `POST /predict`
- `blank_space:10` (or any other `int`, default to `-1`) to specify the CTC blank space index

Example:

- service creation
```
curl -X PUT "http://localhost:8080/services/ocr" -d '{
       "mllib":"caffe",
       "description":"OCR service",
       "type":"supervised",
       "parameters":{
         "input":{
           "connector":"image"
         },        
         "mllib":{                             
           "nclasses":11
         }
       },                                                                                                                            
  "model":{
         "repository":"/path/to/ctc_model/"
       }
     }'
```

- batch prediction
```
curl -X POST "http://localhost:8080/predict" -d '{
       "service":"ocr",
       "parameters":{
         "input":{
           "width":128,
           "height":32
         },
         "output":{
           "ctc":true,
           "blank_label":10
         }
       },
       "data":["/path/to/img1.png","/path/to/img2.png"]
```
