### PR TITLE
JSON output now reports estimated remaining time of training jobs

### DIFF
--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -802,6 +802,8 @@ namespace dd
 	
 	float loss = 0.0;
 	float avg_fb_time = 0.0;
+	float est_remain_time = 0.0;
+	std::string est_remain_time_str;
 	try
 	  {
 	    for (size_t i = 0; i < solver->callbacks().size(); ++i) {
@@ -816,6 +818,7 @@ namespace dd
 	      }
 	    loss /= solver->param_.iter_size();
 	    avg_fb_time /= solver->param_.iter_size();
+	    est_remain_time = avg_fb_time * solver->param_.iter_size() * (solver->param_.max_iter() - solver->iter_) / 1000.0;
 	  }
 	catch(std::exception &e)
 	  {
@@ -842,7 +845,8 @@ namespace dd
 	  }
 	this->add_meas("train_loss",smoothed_loss);
 	this->add_meas("iter_time",avg_fb_time);
-
+	this->add_meas("remain_time",est_remain_time);
+	
 	if ((solver->param_.display() && solver->iter_ % solver->param_.display() == 0)
 	    || (solver->param_.test_interval() && solver->iter_ % solver->param_.test_interval() == 0))
 	  {

--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -227,6 +227,23 @@ namespace dd
       ad.add("measure",meas);
     }
 
+    /**
+     * \brief render estimated remaining time
+     * @param ad data object to hold the estimate
+     */
+    void est_remain_time(APIData &out)
+    {
+      APIData meas = out.getobj("measure");
+      int est_remain_time = static_cast<int>(meas.get("remain_time").get<double>());
+      int seconds = est_remain_time % 60;
+      int minutes = (est_remain_time / 60) % 60;
+      int hours = (est_remain_time / 60 / 60) % 24;
+      int days = est_remain_time / 60 / 60 / 24;
+      std::string est_remain_time_str = std::to_string(days) + "d:" + std::to_string(hours) + "h:" + std::to_string(minutes) + "m:" + std::to_string(seconds) + "s";
+      meas.add("remain_time_str",est_remain_time_str);
+      out.add("measure",meas);
+    }
+    
     TInputConnectorStrategy _inputc; /**< input connector strategy for channeling data in. */
     TOutputConnectorStrategy _outputc; /**< output connector strategy for passing results back to API. */
 

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -254,6 +254,7 @@ namespace dd
 	    {
 	      out.add("status","running");
 	      this->collect_measures(out);
+	      this->est_remain_time(out);
 	      std::chrono::time_point<std::chrono::system_clock> trun = std::chrono::system_clock::now();
 	      out.add("time",std::chrono::duration_cast<std::chrono::seconds>(trun-(*hit).second._tstart).count());
 	      if (ad_params_out.has("measure_hist") && ad_params_out.get("measure_hist").get<bool>())


### PR DESCRIPTION
This implements #355.

Output variables are `remain_train` and `remain_train_str`.