### PR TITLE
Fix calculation of estimated remain_time if remain_time is not available

### DIFF
--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -234,13 +234,15 @@ namespace dd
     void est_remain_time(APIData &out)
     {
       APIData meas = out.getobj("measure");
-      int est_remain_time = static_cast<int>(meas.get("remain_time").get<double>());
-      int seconds = est_remain_time % 60;
-      int minutes = (est_remain_time / 60) % 60;
-      int hours = (est_remain_time / 60 / 60) % 24;
-      int days = est_remain_time / 60 / 60 / 24;
-      std::string est_remain_time_str = std::to_string(days) + "d:" + std::to_string(hours) + "h:" + std::to_string(minutes) + "m:" + std::to_string(seconds) + "s";
-      meas.add("remain_time_str",est_remain_time_str);
+      if (meas.has("remain_time")){    
+        int est_remain_time = static_cast<int>(meas.get("remain_time").get<double>());
+        int seconds = est_remain_time % 60;
+        int minutes = (est_remain_time / 60) % 60;
+        int hours = (est_remain_time / 60 / 60) % 24;
+        int days = est_remain_time / 60 / 60 / 24;
+        std::string est_remain_time_str = std::to_string(days) + "d:" + std::to_string(hours) + "h:" + std::to_string(minutes) + "m:" + std::to_string(seconds) + "s";
+        meas.add("remain_time_str",est_remain_time_str);
+      }
       out.add("measure",meas);
     }
     

--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -242,8 +242,8 @@ namespace dd
         int days = est_remain_time / 60 / 60 / 24;
         std::string est_remain_time_str = std::to_string(days) + "d:" + std::to_string(hours) + "h:" + std::to_string(minutes) + "m:" + std::to_string(seconds) + "s";
         meas.add("remain_time_str",est_remain_time_str);
+        out.add("measure",meas);
       }
-      out.add("measure",meas);
     }
     
     TInputConnectorStrategy _inputc; /**< input connector strategy for channeling data in. */


### PR DESCRIPTION
If 'remain_time' is not obtained yet, DeepDetect throws an error and stops the training.

By doing this we do not calculate the estimated remaining time when we do not have this information