### PR TITLE
Logger refactoring / one logger per service

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -31,7 +31,8 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
 	libleveldb-dev \
 	libsnappy-dev \
 	liblmdb-dev \
-	libutfcpp-dev
+	libutfcpp-dev \
+	libspdlog-dev
 
         # Install ccache symlink wrappers
         pushd /usr/local/bin

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -53,7 +53,7 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
         ##################
         # Not available on 14.04 trusty via package
 	git clone https://github.com/gabime/spdlog.git
-	sudo cp -r include/spdlog /usr/include/
+	sudo cp -r spdlog/include/spdlog /usr/include/
 	
         if [ "$BUILD_CUDA" = 'true' ]; then
         ##################

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -47,6 +47,13 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
         $APT_INSTALL_CMD g++-5
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 \
             --slave /usr/bin/g++ g++ /usr/bin/g++-5
+
+	##################
+        # Install spdlog #
+        ##################
+        # Not available on 14.04 trusty via package
+	git clone https://github.com/gabime/spdlog.git
+	sudo cp -r include/spdlog /usr/include/
 	
         if [ "$BUILD_CUDA" = 'true' ]; then
         ##################
@@ -79,13 +86,6 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
         wget -O "$_cmake_installer" https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh
         sudo bash "$_cmake_installer" --prefix=/usr/local --skip-license
         rm -rf "$_cmake_installer"
-
-	##################
-        # Install spdlog #
-        ##################
-        # Not available on 14.04 trusty via package
-	git clone https://github.com/gabime/spdlog.git
-	sudo cp -r include/spdlog /usr/include/
 	
         ################
         # Install CUDA #

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -31,8 +31,7 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
 	libleveldb-dev \
 	libsnappy-dev \
 	liblmdb-dev \
-	libutfcpp-dev \
-	libspdlog-dev
+	libutfcpp-dev
 
         # Install ccache symlink wrappers
         pushd /usr/local/bin
@@ -81,6 +80,13 @@ if [ "$TRAVIS_OS_NAME" = 'linux' ]; then
         sudo bash "$_cmake_installer" --prefix=/usr/local --skip-license
         rm -rf "$_cmake_installer"
 
+	##################
+        # Install spdlog #
+        ##################
+        # Not available on 14.04 trusty via package
+	git clone https://github.com/gabime/spdlog.git
+	sudo cp -r include/spdlog /usr/include/
+	
         ################
         # Install CUDA #
         ################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -164,7 +164,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn.jetson Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -174,7 +174,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -186,7 +186,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${TENSORFLOW_CC_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -196,7 +196,7 @@ else()
 	  caffe_dd
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
-	  URL https://github.com/beniz/caffe/archive/master.tar.gz
+	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
@@ -210,7 +210,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
@@ -220,7 +220,7 @@ else()
 	caffe_dd
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
-	URL https://github.com/beniz/caffe/archive/master.tar.gz
+	URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
 	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,11 @@ if (CAFFE_INC_DIR AND CAFFE_LIB_DIR)
   # do nothing
 else()
   message(STATUS "Configuring customized caffe")
+  if (USE_DD_SYSLOG)
+    set(USE_SYSLOG 1)
+  else()
+    set(USE_SYSLOG 0)
+  endif()
   if (CUDA_FOUND AND NOT USE_CAFFE_CPU_ONLY)
     if (CUDA_ARCH)
     else()
@@ -155,7 +160,7 @@ else()
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
 	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
+	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
 	  )
@@ -165,7 +170,7 @@ else()
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
 	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn.jetson Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
+	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn.jetson Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
 	  )
@@ -175,7 +180,7 @@ else()
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
 	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
+	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu.cudnn Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
 	  )
@@ -187,7 +192,7 @@ else()
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
 	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${TENSORFLOW_CC_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
+	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${TENSORFLOW_CC_DIR}/tensorflow/tensorflow/contrib/makefile/gen/protobuf/bin:$ENV{PATH} make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
 	  )
@@ -197,7 +202,7 @@ else()
 	  PREFIX caffe_dd
 	  INSTALL_DIR ${CMAKE_BINARY_DIR}
 	  URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
+	  CONFIGURE_COMMAND ln -sf Makefile.config.gpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && make CUDA_ARCH=${CUDA_ARCH} -j${N}
 	  INSTALL_COMMAND ""
 	  BUILD_IN_SOURCE 1
 	  )
@@ -211,7 +216,7 @@ else()
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
 	URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make -j${N}
+	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && ${CMAKE_COMMAND} -E env PATH=${CMAKE_BINARY_DIR}/protobuf/bin:$ENV{PATH} make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
 	)
@@ -221,7 +226,7 @@ else()
 	PREFIX caffe_dd
 	INSTALL_DIR ${CMAKE_BINARY_DIR}
 	URL https://github.com/beniz/caffe/archive/nlogs.tar.gz
-	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && make -j${N}
+	CONFIGURE_COMMAND ln -sf Makefile.config.cpu Makefile.config && echo "OPENCV_VERSION:=${OPENCV_VERSION}" >> Makefile.config && echo "USE_SYSLOG:=${USE_SYSLOG}" >> Makefile.config && make -j${N}
 	INSTALL_COMMAND ""
 	BUILD_IN_SOURCE 1
 	)

--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ Specify the following option via cmake:
 cmake .. -DUSE_SIMSEARCH=ON
 ```
 
+#### Build with logs output into syslog
+
+Specify the following option via cmake:
+```
+cmake .. -DUSE_DD_SYSLOG=ON
+```
+
 ### Run tests
 
 Note: running tests requires the automated download of ~75Mb of datasets, and computations may take around thirty minutes on a CPU-only machines.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Below are instructions for Ubuntu 14.04 LTS. For other Linux and Unix systems, s
 
 Beware of dependencies, typically on Debian/Ubuntu Linux, do:
 ```
-sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libcppnetlib-dev libboost-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev
+sudo apt-get install build-essential libgoogle-glog-dev libgflags-dev libeigen3-dev libopencv-dev libcppnetlib-dev libboost-dev libboost-iostreams-dev libcurlpp-dev libcurl4-openssl-dev protobuf-compiler libopenblas-dev libhdf5-dev libprotobuf-dev libleveldb-dev libsnappy-dev liblmdb-dev libutfcpp-dev cmake libgoogle-perftools-dev unzip python-setuptools python-dev libspdlog-dev
 ```
 
 #### Default build with Caffe

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,9 @@
 if (NOT CUDA_FOUND)
   add_definitions(-DCPU_ONLY)
 endif()
+if (USE_DD_SYSLOG)
+  add_definitions(-DUSE_DD_SYSLOG)
+endif()
 
 set(ddetect_SOURCES deepdetect.h deepdetect.cc caffelib.h caffelib.cc mllibstrategy.h mlmodel.h mlservice.h caffemodel.h caffemodel.cc inputconnectorstrategy.h imginputfileconn.h csvinputfileconn.h csvinputfileconn.cc svminputfileconn.h svminputfileconn.cc txtinputfileconn.h txtinputfileconn.cc caffeinputconns.h caffeinputconns.cc commandlineapi.h commandlineapi.cc commandlinejsonapi.h commandlinejsonapi.cc apidata.h apidata.cc jsonapi.h jsonapi.cc httpjsonapi.cc httpjsonapi.h ext/rmustache/mustache.h ext/rmustache/mustache.cc generators/net_generator.h generators/net_caffe.h generators/net_caffe.cc generators/net_caffe_mlp.h generators/net_caffe_mlp.cc generators/net_caffe_convnet.h generators/net_caffe_convnet.cc generators/net_caffe_resnet.h generators/net_caffe_resnet.cc)
 if (USE_TF)

--- a/src/apistrategy.h
+++ b/src/apistrategy.h
@@ -37,7 +37,11 @@ namespace dd
     public:
       APIStrategy()
 	{
+#ifdef USE_DD_SYSLOG
+	  _logger = spdlog::syslog_logger("api");
+#else
 	  _logger = spdlog::stdout_logger_mt("api");
+#endif
 	};
       ~APIStrategy()
 	{

--- a/src/apistrategy.h
+++ b/src/apistrategy.h
@@ -24,6 +24,7 @@
 
 #include "dd_types.h"
 #include "services.h"
+#include <spdlog/spdlog.h>
 
 namespace dd
 {
@@ -34,13 +35,20 @@ namespace dd
   class APIStrategy : public Services
     {
     public:
-      APIStrategy() {};
-      ~APIStrategy() {};
+      APIStrategy()
+	{
+	  _logger = spdlog::stdout_logger_mt("api");
+	};
+      ~APIStrategy()
+	{
+	  spdlog::drop("api");
+	}
       
       /**
        * \brief handling of command line parameters
        */
       int boot(int argc, char *argv[]);
+      std::shared_ptr<spdlog::logger> _logger; /**< api logger. */
     };
 }
 

--- a/src/caffeinputconns.h
+++ b/src/caffeinputconns.h
@@ -433,6 +433,7 @@ namespace dd
     
     CSVCaffeInputFileConn *_cifc = nullptr;
     APIData _adconf;
+    std::shared_ptr<spdlog::logger> _logger;
   };
   
   class CSVCaffeInputFileConn : public CSVInputFileConn, public CaffeInputInterface

--- a/src/caffemodel.cc
+++ b/src/caffemodel.cc
@@ -22,7 +22,6 @@
 #include "caffemodel.h"
 #include "mllibstrategy.h"
 #include "utils/fileops.hpp"
-#include <glog/logging.h>
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -48,13 +47,14 @@ namespace dd
       _solver = ad.get("solver").get<std::string>();
     if (ad.has("repository"))
       {
-       	if (read_from_repository(ad.get("repository").get<std::string>()))
+       	if (read_from_repository(ad.get("repository").get<std::string>(),spdlog::get("api")))
 	  throw MLLibBadParamException("error reading or listing Caffe models in repository " + _repo);
       }
     read_corresp_file();
   }
   
-  int CaffeModel::read_from_repository(const std::string &repo)
+  int CaffeModel::read_from_repository(const std::string &repo,
+				       const std::shared_ptr<spdlog::logger> &logger)
   {
     static std::string deploy = "deploy.prototxt";
     static std::string train = ".prototxt";
@@ -68,7 +68,7 @@ namespace dd
     int e = fileops::list_directory(repo,true,false,lfiles);
     if (e != 0)
       {
-	LOG(ERROR) << "error reading or listing caffe models in repository " << repo << std::endl;
+	logger->error("error reading or listing caffe models in repository {}",repo);
 	return 1;
       }
     std::string deployf,trainf,weightsf,correspf,solverf,sstatef;
@@ -127,13 +127,7 @@ namespace dd
     if (_solver.empty())
       _solver = solverf;
     if (_sstate.empty())
-      _sstate = sstatef;
-    
-    /*    if (deployf.empty() || weightsf.empty())
-      {
-	LOG(ERROR) << "missing caffe model file(s) in repository\n";
-	return CaffeModel();
-	}*/
+      _sstate = sstatef;    
     return 0;
   }
 }

--- a/src/caffemodel.h
+++ b/src/caffemodel.h
@@ -24,6 +24,7 @@
 
 #include "mlmodel.h"
 #include "apidata.h"
+#include <spdlog/spdlog.h>
 #include <string>
 
 namespace dd
@@ -37,7 +38,8 @@ namespace dd
       :MLModel(repo) {}
     ~CaffeModel() {};
 
-    int read_from_repository(const std::string &repo);
+    int read_from_repository(const std::string &repo,
+			     const std::shared_ptr<spdlog::logger> &logger);
     
     std::string _def; /**< file name of the model definition in the form of a protocol buffer message description. */
     std::string _trainf; /**< file name of the training model definition. */

--- a/src/csvinputfileconn.cc
+++ b/src/csvinputfileconn.cc
@@ -20,7 +20,6 @@
  */
 
 #include "csvinputfileconn.h"
-#include <glog/logging.h>
 
 namespace dd
 {
@@ -211,8 +210,8 @@ namespace dd
 		vals.push_back(c);
 	      else
 		{
-		  LOG(ERROR) << "line " << nlines << ": skipping column " << col_name << " / not a number";
-		  LOG(ERROR) << hline << std::endl;
+		  _logger->error("line {}: skipping column {} / not a number",nlines,col_name);
+		  _logger->error(hline);
 		  throw InputConnectorBadParamException("column " + col_name + " is not a number, use categoricals or ignore parameters instead");
 		}
 	    }
@@ -263,7 +262,7 @@ namespace dd
 				  const std::string &fname)
   {
       std::ifstream csv_file(fname,std::ios::binary);
-      LOG(INFO) << "fname=" << fname << " / open=" << csv_file.is_open() << std::endl;
+      _logger->info("fname={} / open={}",fname,csv_file.is_open());
       if (!csv_file.is_open())
 	throw InputConnectorBadParamException("cannot open file " + fname);
       std::string hline;
@@ -297,8 +296,8 @@ namespace dd
 		{
 		  if (cu >= _detect_cols)
 		    {
-		      LOG(ERROR) << "line " << l << " has more columns than headers\n";
-		      LOG(ERROR) << hline << std::endl;
+		      _logger->error("line {} has more columns than headers",l);
+		      _logger->error(hline);
 		      throw InputConnectorBadParamException("line has more columns than headers");
 		    }
 		  if ((igit=_ignored_columns_pos.find(cu))!=_ignored_columns_pos.end())
@@ -376,7 +375,7 @@ namespace dd
 	    std::cout << std::endl;*/
 	  //debug
 	}
-      LOG(INFO) << "read " << nlines << " lines from " << fname << std::endl;
+      _logger->info("read {} lines from {}",nlines,fname);
       csv_file.close();
       
       // test file, if any.
@@ -409,7 +408,7 @@ namespace dd
 		std::cout << std::endl;*/
 	      //debug
 	    }
-	  LOG(INFO) << "read " << nlines << " lines from " << _csv_test_fname << std::endl;
+	  _logger->info("read {} lines from {}", nlines, _csv_test_fname);
 	  csv_test_file.close();
 	}
 
@@ -419,7 +418,7 @@ namespace dd
       if (_csv_test_fname.empty() && _test_split > 0)
 	{
 	  split_data();
-	  LOG(INFO) << "data split test size=" << _csvdata_test.size() << " / remaining data size=" << _csvdata.size() << std::endl;
+	  _logger->info("data split test size={} / remaining data size={}",_csvdata_test.size(),_csvdata.size());
 	}
       if (!_ignored_columns.empty() || !_categoricals.empty())
 	update_columns();

--- a/src/csvinputfileconn.h
+++ b/src/csvinputfileconn.h
@@ -49,6 +49,7 @@ namespace dd
     
     CSVInputFileConn *_cifc = nullptr;
     APIData _adconf;
+    std::shared_ptr<spdlog::logger> _logger;
   };
   
   class CSVline
@@ -361,7 +362,7 @@ namespace dd
 	      DataEl<DDCsv> ddcsv;
 	      ddcsv._ctype._cifc = this;
 	      ddcsv._ctype._adconf = ad_input;
-	      ddcsv.read_element(_csv_fname);
+	      ddcsv.read_element(_csv_fname,this->_logger);
 	    }
 	  else // training from posted data (in-memory)
 	    {
@@ -370,7 +371,7 @@ namespace dd
 		  DataEl<DDCsv> ddcsv;
 		  ddcsv._ctype._cifc = this;
 		  ddcsv._ctype._adconf = ad_input;
-		  ddcsv.read_element(_uris.at(i));
+		  ddcsv.read_element(_uris.at(i),this->_logger);
 		}
 	      if (_scale)
 		{
@@ -401,7 +402,7 @@ namespace dd
 	      DataEl<DDCsv> ddcsv;
 	      ddcsv._ctype._cifc = this;
 	      ddcsv._ctype._adconf = ad_input;
-	      ddcsv.read_element(_uris.at(i));
+	      ddcsv.read_element(_uris.at(i),this->_logger);
 	    }
 	}
       if (_csvdata.empty() && _db_fname.empty())

--- a/src/generators/net_caffe.h
+++ b/src/generators/net_caffe.h
@@ -24,6 +24,7 @@
 
 #include "net_generator.h"
 #include "caffe/caffe.hpp"
+#include <spdlog/spdlog.h>
 
 namespace dd
 {
@@ -53,7 +54,7 @@ namespace dd
   public:
   NetInputCaffe(caffe::NetParameter *net_params,
 		caffe::NetParameter *dnet_params)
-    :NetInput<TInputCaffe>(),_net_params(net_params),_dnet_params(dnet_params) 
+    :NetInput<TInputCaffe>(),_net_params(net_params),_dnet_params(dnet_params)
     {
       _net_params->set_name("net");
       _dnet_params->set_name("dnet");
@@ -77,8 +78,9 @@ namespace dd
   {
   public:
     NetLayersCaffe(caffe::NetParameter *net_params,
-		   caffe::NetParameter *dnet_params)
-      :NetLayers(),_net_params(net_params),_dnet_params(dnet_params) {}
+		   caffe::NetParameter *dnet_params,
+		   std::shared_ptr<spdlog::logger> &logger)
+      :NetLayers(),_net_params(net_params),_dnet_params(dnet_params),_logger(logger) {}
     
     //void add_basic_block() {}
     void configure_net(const APIData &ad) { (void)ad; }
@@ -167,6 +169,7 @@ namespace dd
     
     caffe::NetParameter *_net_params;
     caffe::NetParameter *_dnet_params;
+    std::shared_ptr<spdlog::logger> _logger;
   };
 
   class NetLossCaffe
@@ -180,9 +183,10 @@ namespace dd
     {
     public:
       NetCaffe(caffe::NetParameter *net_params,
-	       caffe::NetParameter *dnet_params)
+	       caffe::NetParameter *dnet_params,
+	       std::shared_ptr<spdlog::logger> &logger)
 	:_net_params(net_params),_dnet_params(dnet_params),
-	_nic(net_params,dnet_params),_nlac(net_params,dnet_params) {}
+	_nic(net_params,dnet_params),_nlac(net_params,dnet_params,logger),_logger(logger) {}
       ~NetCaffe() {}
 
     public:
@@ -192,10 +196,9 @@ namespace dd
       TNetInputCaffe _nic;
       TNetLayersCaffe _nlac;
       //TNetLossCaffe _nloc
+      std::shared_ptr<spdlog::logger> _logger;
     };
   
 }
-
-//#include "net_caffe_mlp.h"
 
 #endif

--- a/src/generators/net_caffe_convnet.h
+++ b/src/generators/net_caffe_convnet.h
@@ -31,8 +31,9 @@ namespace dd
   {
   public:
   NetLayersCaffeConvnet(caffe::NetParameter *net_params,
-			caffe::NetParameter *dnet_params)
-    :NetLayersCaffeMLP(net_params,dnet_params) 
+			caffe::NetParameter *dnet_params,
+			std::shared_ptr<spdlog::logger> &logger)
+    :NetLayersCaffeMLP(net_params,dnet_params,logger) 
       {
 	net_params->set_name("convnet");
 	dnet_params->set_name("convnet");

--- a/src/generators/net_caffe_mlp.h
+++ b/src/generators/net_caffe_mlp.h
@@ -31,8 +31,9 @@ namespace dd
   {
   public:
   NetLayersCaffeMLP(caffe::NetParameter *net_params,
-		    caffe::NetParameter *dnet_params)
-    :NetLayersCaffe(net_params,dnet_params) 
+		    caffe::NetParameter *dnet_params,
+		    std::shared_ptr<spdlog::logger> &logger)
+    :NetLayersCaffe(net_params,dnet_params,logger) 
       {
 	net_params->set_name("mlp");
 	dnet_params->set_name("mlp");

--- a/src/generators/net_caffe_resnet.cc
+++ b/src/generators/net_caffe_resnet.cc
@@ -223,7 +223,7 @@ namespace dd
     std::vector<std::pair<int,int>> cr_layers;
     std::vector<int> fc_layers;
     parse_res_layers(layers,cr_layers,fc_layers,depth,n);
-    LOG(INFO) << "generating ResNet with depth=" << depth << " / n=" << n << std::endl;
+    _logger->info("generating ResNet with depth={} / n={}",depth,n);
     std::string bottom = "data";
     
     //std::vector<int> stages = {16, 64, 128, 256};
@@ -288,7 +288,7 @@ namespace dd
     std::vector<std::pair<int,int>> cr_layers;
     std::vector<int> fc_layers;
     parse_res_layers(layers,cr_layers,fc_layers,depth,n);
-    LOG(INFO) << "generating CharText ResNet with depth=" << depth << " / n=" << n << std::endl;
+    _logger->info("generating CharText ResNet with depth={} / n={}",depth,n);
     if (ad_mllib.has("dropout"))
       dropout = ad_mllib.get("dropout").get<double>();
     bool bn = false;
@@ -367,7 +367,7 @@ namespace dd
     int depth = layers.size();
     int n = 2;
         
-    LOG(INFO) << "generating MLP ResNet with depth=" << depth << " / n=" << n << std::endl;
+    _logger->info("generating MLP ResNet with depth={} / n={}",depth,n);
     std::string bottom = "data";
    
     std::string top = "fc1";

--- a/src/generators/net_caffe_resnet.h
+++ b/src/generators/net_caffe_resnet.h
@@ -31,8 +31,9 @@ namespace dd
   {
   public:
     NetLayersCaffeResnet(caffe::NetParameter *net_params,
-			 caffe::NetParameter *dnet_params)
-      :NetLayersCaffeConvnet(net_params,dnet_params) 
+			 caffe::NetParameter *dnet_params,
+			 std::shared_ptr<spdlog::logger> &logger)
+      :NetLayersCaffeConvnet(net_params,dnet_params,logger) 
       {
 	net_params->set_name("resnet");
 	dnet_params->set_name("resnet");

--- a/src/inputconnectorstrategy.h
+++ b/src/inputconnectorstrategy.h
@@ -25,6 +25,7 @@
 #include "apidata.h"
 #include "utils/fileops.hpp"
 #include "utils/httpclient.hpp"
+#include <spdlog/spdlog.h>
 #include <exception>
 
 namespace dd
@@ -40,8 +41,10 @@ namespace dd
     DataEl() {}
     ~DataEl() {}
 
-    int read_element(const std::string &uri)
+    int read_element(const std::string &uri,
+		     std::shared_ptr<spdlog::logger> &logger)
     {
+      _ctype._logger = logger;
       bool dir = false;
       if (uri.find("https://") != std::string::npos
 	  || uri.find("http://") != std::string::npos
@@ -112,7 +115,7 @@ namespace dd
   public:
     InputConnectorStrategy() {}
     InputConnectorStrategy(const InputConnectorStrategy &i)
-      :_model_repo(i._model_repo) {}
+      :_model_repo(i._model_repo),_logger(i._logger) {}
     ~InputConnectorStrategy() {}
     
     /**
@@ -179,6 +182,7 @@ namespace dd
 
     std::vector<std::string> _uris;
     std::string _model_repo; /**< model repository, useful when connector needs to read from saved data (e.g. vocabulary). */
+    std::shared_ptr<spdlog::logger> _logger;
   };
   
 }

--- a/src/jsonapi.cc
+++ b/src/jsonapi.cc
@@ -26,7 +26,6 @@
 #include "ext/rapidjson/stringbuffer.h"
 #include "ext/rapidjson/reader.h"
 #include "ext/rapidjson/writer.h"
-#include <glog/logging.h>
 
 namespace dd
 {
@@ -265,7 +264,7 @@ namespace dd
   {
     if (sname.empty())
       {
-	LOG(ERROR) << "missing service resource name: " << sname << std::endl;
+	_logger->error("missing service resource name: {}",sname);
 	return dd_not_found_404();
       }
 
@@ -273,7 +272,7 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	LOG(ERROR) << "JSON parsing error on string: " << jstr << std::endl;
+	_logger->error("JSON parsing error on string: {}",jstr);
 	return dd_bad_request_400();
       }
 
@@ -299,7 +298,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	return dd_bad_request_400();
       }
     catch(...)
@@ -325,7 +324,7 @@ namespace dd
 		  add_service(sname,std::move(MLService<CaffeLib,SVMCaffeInputFileConn,SupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
 		else return dd_input_connector_not_found_1004();
 		if (JsonAPI::store_json_blob(cmodel._repo,jstr)) // store successful call json blob
-		  LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << cmodel._repo << std::endl;
+		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,cmodel._repo);
 	      }
 	    else if (type == "unsupervised")
 	      {
@@ -339,7 +338,7 @@ namespace dd
 		  add_service(sname,std::move(MLService<CaffeLib,SVMCaffeInputFileConn,UnsupervisedOutput,CaffeModel>(sname,cmodel,description)),ad);
 		else return dd_input_connector_not_found_1004();
 		if (JsonAPI::store_json_blob(cmodel._repo,jstr)) // store successful call json blob
-		  LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << cmodel._repo << std::endl;
+		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,cmodel._repo);
 	      }
 	    else
 	      {
@@ -357,7 +356,7 @@ namespace dd
 		  add_service(sname,std::move(MLService<TFLib,ImgTFInputFileConn,SupervisedOutput,TFModel>(sname,tfmodel,description)),ad);
 		else return dd_input_connector_not_found_1004();
 		if (JsonAPI::store_json_blob(tfmodel._repo,jstr)) // store successful call json blob
-		  LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << tfmodel._repo << std::endl;
+		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,tfmodel._repo);
 	      }
 	    else if (type == "unsupervised")
 	      {
@@ -365,7 +364,7 @@ namespace dd
 		  add_service(sname,std::move(MLService<TFLib,ImgTFInputFileConn,UnsupervisedOutput,TFModel>(sname,tfmodel,description)),ad);
 		else return dd_input_connector_not_found_1004();
 		if (JsonAPI::store_json_blob(tfmodel._repo,jstr)) // store successful call json blob
-		  LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << tfmodel._repo << std::endl;
+		  _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,tfmodel._repo);
 	      }
 	    else
 	      {
@@ -386,7 +385,7 @@ namespace dd
 	      add_service(sname,std::move(MLService<XGBLib,TxtXGBInputFileConn,SupervisedOutput,XGBModel>(sname,xmodel,description)),ad);
 	    else return dd_input_connector_not_found_1004();
 	    if (JsonAPI::store_json_blob(xmodel._repo,jstr)) // store successful call json blob
-	      LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << xmodel._repo << std::endl;
+	      _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,xmodel._repo);
 	  }
 #endif
 #ifdef USE_TSNE
@@ -399,7 +398,7 @@ namespace dd
 	      add_service(sname,std::move(MLService<TSNELib,TxtTSNEInputFileConn,UnsupervisedOutput,TSNEModel>(sname,tmodel,description)),ad);
 	    else return dd_input_connector_not_found_1004();
 	    if (JsonAPI::store_json_blob(tmodel._repo,jstr)) // store successful call json blob
-	      LOG(ERROR) << "couldn't write " << JsonAPI::_json_blob_fname << " file in model repository " << tmodel._repo << std::endl; 
+	      _logger->error("couldn't write {} file in model repository {}",JsonAPI::_json_blob_fname,tmodel._repo);
 	  }
 #endif
 	else
@@ -462,7 +461,7 @@ namespace dd
 	d.Parse(jstr.c_str());
 	if (d.HasParseError())
 	  {
-	    LOG(ERROR) << "JSON parsing error on string: " << jstr << std::endl;
+	    _logger->error("JSON parsing error on string: {}",jstr);
 	    return dd_bad_request_400();
 	  }
       }
@@ -475,7 +474,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	return dd_bad_request_400();
       }
     catch(...)
@@ -505,7 +504,7 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	LOG(ERROR) << "JSON parsing error on string: " << jstr << std::endl;
+	_logger->error("JSON parsing error on string: {}",jstr);
 	return dd_bad_request_400();
       }
 
@@ -531,7 +530,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	return dd_bad_request_400();
       }
     catch(...)
@@ -622,7 +621,7 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	LOG(ERROR) << "JSON parsing error on string: " << jstr << std::endl;
+	_logger->error("JSON parsing error on string: {}",jstr);
 	return dd_bad_request_400();
       }
   
@@ -648,7 +647,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	return dd_bad_request_400();
       }
     catch(...)
@@ -664,7 +663,7 @@ namespace dd
 	this->train(ad,sname,out); // we ignore return status, stored in out data object
 	mrepo = out.getobj("model").get("repository").get<std::string>();
 	if (JsonAPI::store_json_blob(mrepo,jstr)) // store successful call json blob
-	  LOG(ERROR) << "couldn't write to" << JsonAPI::_json_blob_fname << " file in model repository " << mrepo << std::endl;
+	  _logger->error("couldn't write to {} file in model repository {}",JsonAPI::_json_blob_fname,mrepo);
       }
     catch (InputConnectorBadParamException &e)
       {
@@ -706,7 +705,7 @@ namespace dd
       }
     jtrain.AddMember("head",jhead,jtrain.GetAllocator());
     if (JsonAPI::store_json_blob(mrepo,jrender(jtrain))) // store successful call json blob
-      LOG(ERROR) << "couldn't write to " << JsonAPI::_json_blob_fname << " file in model repository " << mrepo << std::endl;
+      _logger->error("couldn't write to {} file in model repository {}",JsonAPI::_json_blob_fname,mrepo);
     return jtrain;
   }
 
@@ -716,7 +715,7 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	LOG(ERROR) << "JSON parsing error on string: " << jstr << std::endl;
+	_logger->error("JSON parsing error on string: {}",jstr);
 	return dd_bad_request_400();
       }
 
@@ -742,7 +741,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	return dd_bad_request_400();
       }
     catch(...)
@@ -779,7 +778,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	dout = dd_bad_request_400();
       }
     catch (std::exception &e)
@@ -814,7 +813,7 @@ namespace dd
     if (dout.HasMember("status"))
       {
 	jhead.AddMember("status",JVal().SetString("error",jtrain.GetAllocator()),jtrain.GetAllocator());
-	LOG(ERROR) << jrender(dout["status"]) << std::endl;
+	_logger->error(jrender(dout["status"]));
 	/*JVal &jvout = dout["status"];
 	  jout.AddMember("Error",jvout,jtrain.GetAllocator());*/ // XXX: beware, acquiring the status appears to lead to corrupted rapidjson strings
       }
@@ -824,7 +823,7 @@ namespace dd
       {
 	std::string mrepo = out.getobj("model").get("repository").get<std::string>();
 	if (JsonAPI::store_json_blob(mrepo,jrender(jtrain)))
-	LOG(ERROR) << "couldn't write to " << JsonAPI::_json_blob_fname << " file in model repository " << mrepo << std::endl;
+	  _logger->error("couldn't write to {} file in model repository {}",JsonAPI::_json_blob_fname,mrepo);
       }
     return jtrain;
   }
@@ -835,7 +834,7 @@ namespace dd
     d.Parse(jstr.c_str());
     if (d.HasParseError())
       {
-	LOG(ERROR) << "JSON parsing error on string: " << jstr << std::endl;
+	_logger->error("JSON parsing error on string: {}",jstr);
 	return dd_bad_request_400();
       }
   
@@ -861,7 +860,7 @@ namespace dd
       }
     catch(RapidjsonException &e)
       {
-	LOG(ERROR) << "JSON error " << e.what() << std::endl;
+	_logger->error("JSON error {}",e.what());
 	return dd_bad_request_400();
       }
     catch(...)

--- a/src/mllibstrategy.h
+++ b/src/mllibstrategy.h
@@ -24,6 +24,7 @@
 
 #include "apidata.h"
 #include "utils/fileops.hpp"
+#include <spdlog/spdlog.h>
 #include <atomic>
 #include <exception>
 #include <mutex>
@@ -75,7 +76,7 @@ namespace dd
      * \brief copy-constructor
      */
     MLLib(MLLib &&mll) noexcept
-      :_inputc(mll._inputc),_outputc(mll._outputc),_mlmodel(mll._mlmodel),_meas(mll._meas),_tjob_running(mll._tjob_running.load())
+      :_inputc(mll._inputc),_outputc(mll._outputc),_mlmodel(mll._mlmodel),_meas(mll._meas),_tjob_running(mll._tjob_running.load()),_logger(mll._logger)
       {}
     
     /**
@@ -245,7 +246,7 @@ namespace dd
         out.add("measure",meas);
       }
     }
-    
+
     TInputConnectorStrategy _inputc; /**< input connector strategy for channeling data in. */
     TOutputConnectorStrategy _outputc; /**< output connector strategy for passing results back to API. */
 
@@ -263,6 +264,8 @@ namespace dd
     bool _online = false; /**< whether the algorithm is online, i.e. it interleaves training and prediction calls.
 			     When not, prediction calls are rejected while training is running. */
 
+    std::shared_ptr<spdlog::logger> _logger; /**< mllib logger. */
+    
   protected:
     std::mutex _meas_per_iter_mutex; /**< mutex over measures history. */
     std::mutex _meas_mutex; /** mutex around current measures. */

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -84,7 +84,9 @@ namespace dd
 	      const TMLModel &mlmodel,
 	      const std::string &description="")
       :TMLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>(mlmodel),_sname(sname),_description(description),_tjobs_counter(0)
-      {}
+      {
+	this->_logger = spdlog::stdout_logger_mt(_sname);
+      }
     
     /**
      * \brief copy-constructor
@@ -100,6 +102,7 @@ namespace dd
     ~MLService() 
       {
 	kill_jobs();
+	spdlog::drop(_sname);
       }
 
     /**
@@ -117,6 +120,8 @@ namespace dd
       this->_inputc.init(ad.getobj("parameters").getobj("input"));
       this->_outputc.init(ad.getobj("parameters").getobj("output"));
       this->init_mllib(ad.getobj("parameters").getobj("mllib"));
+      this->_inputc._logger = this->_logger;
+      this->_outputc._logger = this->_logger;
     }
 
     /**

--- a/src/mlservice.h
+++ b/src/mlservice.h
@@ -85,7 +85,11 @@ namespace dd
 	      const std::string &description="")
       :TMLLib<TInputConnectorStrategy,TOutputConnectorStrategy,TMLModel>(mlmodel),_sname(sname),_description(description),_tjobs_counter(0)
       {
+#ifdef USE_DD_SYSLOG
+	this->_logger = spdlog::syslog_logger(_sname);
+#else
 	this->_logger = spdlog::stdout_logger_mt(_sname);
+#endif
       }
     
     /**

--- a/src/outputconnectorstrategy.h
+++ b/src/outputconnectorstrategy.h
@@ -29,6 +29,7 @@
 #include <numeric>
 #include <Eigen/Dense>
 #include "utils/utils.hpp"
+#include <spdlog/spdlog.h>
 
 namespace dd
 {
@@ -95,6 +96,8 @@ namespace dd
      * @param ad_out data object as the call response
      */
     void finalize(const APIData &ad_in, APIData &ad_out, MLModel *mlm=nullptr);
+
+    std::shared_ptr<spdlog::logger> _logger;
   };
 
   /**

--- a/src/services.h
+++ b/src/services.h
@@ -40,6 +40,7 @@
 #ifdef USE_TSNE
 #include "tsnelib.h"
 #endif
+#include <spdlog/spdlog.h>
 #include <vector>
 #include <mutex>
 #include <chrono>
@@ -259,8 +260,9 @@ namespace dd
 	{
 	  throw ServiceForbiddenException("Service already exists");
 	}
-
+      
       visitor_init vi(ad);
+      auto llog = spdlog::get(sname);
       try
 	{
 	  mapbox::util::apply_visitor(vi,mls);
@@ -269,22 +271,22 @@ namespace dd
 	}
       catch (InputConnectorBadParamException &e)
 	{
-	  LOG(ERROR) << "service creation input connector bad param: " << e.what() << std::endl;
+	  llog->error("service creation input connector bad param: {}",e.what());
 	  throw;
 	}
       catch (MLLibBadParamException &e)
 	{
-	  LOG(ERROR) << "service creation mllib bad param: " << e.what() << std::endl;
+	  llog->error("service creation mllib bad param: {}",e.what());
 	  throw;
 	}
       catch (MLLibInternalException &e)
 	{
-	  LOG(ERROR) << "service creation mllib internal error: " << e.what() << std::endl;
+	  llog->error("service creation mllib internal error: {}",e.what());
 	  throw;
 	}
       catch(...)
 	{
-	  LOG(ERROR) << "service creation call failed\n";
+	  llog->error("service creation call failed");
 	  throw;
 	}
     }
@@ -302,6 +304,7 @@ namespace dd
       auto hit = _mlservices.begin();
       if ((hit=_mlservices.find(sname))!=_mlservices.end())
 	{
+	  auto llog = spdlog::get(sname);
 	  if (ad.has("clear"))
 	    {
 	      visitor_clear vc(ad);
@@ -311,24 +314,25 @@ namespace dd
 		}
 	      catch (MLLibBadParamException &e)
 		{
-		  LOG(ERROR) << "service " << sname << " mllib bad param: " << e.what() << std::endl;
+		  llog->error("mllib bad param: {}",e.what());
 		  throw;
 		}
 	      catch (MLLibInternalException &e)
 		{
-		  LOG(ERROR) << "service " << sname << " mllib internal error: " << e.what() << std::endl;
+		  llog->error("mllib internal error: {}",e.what());
 	  	  throw;
 		}
 	      catch(...)
 		{
-		  LOG(ERROR) << "service " << sname << " delete service call failed\n";
+		  llog->error("delete service call failed");
 	  	  throw;
 		}
 	    }
 	  _mlservices.erase(hit);
 	  return true;
 	}
-      LOG(ERROR) << "cannot find service " << sname << " for removal\n";
+      auto llog = spdlog::get("api");
+      llog->error("cannot find service for removal");
       return false;
     }
 
@@ -370,6 +374,7 @@ namespace dd
       visitor_train vt;
       vt._ad = ad;
       output pout;
+      auto llog = spdlog::get(sname);
       try
 	{
 	  auto hit = get_service_it(sname);
@@ -377,25 +382,25 @@ namespace dd
 	}
       catch (InputConnectorBadParamException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib bad param: " << e.what() << std::endl;
+	  llog->error("mllib bad param: {}",e.what());
 	  pout._status = -2;
 	  throw;
 	}
       catch (MLLibBadParamException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib bad param: " << e.what() << std::endl;
+	  llog->error("mllib bad param: {}",e.what());
 	  pout._status = -2;
 	  throw;
 	}
       catch (MLLibInternalException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib internal error: " << e.what() << std::endl;
+	  llog->error("mllib internal error: {}",e.what());
 	  pout._status = -1;
 	  throw;
 	}
       catch(...)
 	{
-	  LOG(ERROR) << "service " << sname << " training call failed\n";
+	  llog->error("training call failed");
 	  pout._status = -1;
 	  throw;
 	}
@@ -433,7 +438,8 @@ namespace dd
 	}
       catch(...)
 	{
-	  LOG(ERROR) << "service " << sname << " training status call failed\n";
+	  auto llog = spdlog::get(sname);
+	  llog->error("training status call failed");
 	  pout._status = -1;
 	  throw;
 	}
@@ -459,7 +465,8 @@ namespace dd
 	}
       catch(...)
 	{
-	  LOG(ERROR) << "service " << sname << " training delete call failed\n";
+	  auto llog = spdlog::get(sname);
+	  llog->error("training delete call failed");
 	  pout._status = -1;
 	  throw;
 	}
@@ -479,6 +486,7 @@ namespace dd
       visitor_predict vp;
       vp._ad = ad;
       output pout;
+      auto llog = spdlog::get(sname);
       try
 	{
 	  auto hit = get_service_it(sname);
@@ -486,31 +494,31 @@ namespace dd
 	}
       catch (InputConnectorBadParamException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib bad param: " << e.what() << std::endl;
+	  llog->error("mllib bad param: {}",e.what());
 	  pout._status = -2;
 	  throw;
 	}
       catch (MLLibBadParamException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib bad param: " << e.what() << std::endl;
+	  llog->error("mllib bad param: {}",e.what());
 	  pout._status = -2;
 	  throw;
 	}
       catch (MLLibInternalException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib internal error: " << e.what() << std::endl;
+	  llog->error("mllib internal error: {}",e.what());
 	  pout._status = -1;
 	  throw;
 	}
       catch (MLServiceLockException &e)
 	{
-	  LOG(ERROR) << "service " << sname << " mllib lock error: " << e.what() << std::endl;
+	  llog->error("mllib lock error: {}",e.what());
 	  pout._status = -3;
 	  throw;
 	}
       catch(...)
 	{
-	  LOG(ERROR) << "service " << sname << " prediction call failed\n";
+	  llog->error("prediction call failed");
 	  pout._status = -1;
 	  throw;
 	}

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -268,6 +268,9 @@ namespace dd
      */
     void finalize(const APIData &ad_in, APIData &ad_out, MLModel *mlm)
     {
+#ifndef USE_SIMSEARCH
+      (void)mlm;
+#endif
       SupervisedOutput bcats(*this);
       bool regression = false;
       bool autoencoder = false;
@@ -983,6 +986,9 @@ namespace dd
 	       const bool &has_bbox, const bool &has_roi,
 	       const std::unordered_set<std::string> &indexed_uris) const
     {
+#ifndef USE_SIMSEARCH
+      (void)indexed_uris;
+#endif
       static std::string cl = "classes";
       static std::string ve = "vector";
       static std::string ae = "losses";

--- a/src/svminputfileconn.cc
+++ b/src/svminputfileconn.cc
@@ -21,7 +21,6 @@
 
 #include "svminputfileconn.h"
 #include "utils/utils.hpp"
-#include <glog/logging.h>
 
 namespace dd
 {
@@ -114,7 +113,7 @@ namespace dd
 				  const std::string &fname)
   {
     std::ifstream svm_file(fname,std::ios::binary);
-    LOG(INFO) << "SVM fname=" << fname << " / open=" << svm_file.is_open() << std::endl;
+    _logger->info("SVM fname={} / open={}",fname,svm_file.is_open());
     if (!svm_file.is_open())
       throw InputConnectorBadParamException("cannot open file " + fname);
     std::string hline;
@@ -145,8 +144,8 @@ namespace dd
     svm_file.clear();
     svm_file.seekg(0,std::ios::beg);
 
-    LOG(INFO) << "total number of dimensions=" << _fids.size() << std::endl;
-
+    _logger->info("total number of dimensions={}",_fids.size());
+    
     // read data
     int nlines = 0;
     while(std::getline(svm_file,hline))
@@ -158,8 +157,8 @@ namespace dd
 	++nlines;
       }
       svm_file.close();
-      LOG(INFO) << "read " << nlines << " lines from SVM data file";
-
+      _logger->info("read {} lines from SVM data file",nlines);
+  
       if (!_svm_test_fname.empty())
 	{
 	  int tnlines = 0;
@@ -184,7 +183,7 @@ namespace dd
       if (_svm_test_fname.empty() && _test_split > 0)
 	{
 	  split_data();
-	  LOG(INFO) << "data split test size=" << _svmdata_test.size() << " / remaining data size=" << _svmdata.size() << std::endl;
+	  _logger->info("data split test size={} / remaining data size={}",_svmdata_test.size(),_svmdata.size());
 	}
   }
 
@@ -228,7 +227,7 @@ namespace dd
 	_fids.insert(fid);
       }
     in.close();
-    LOG(INFO) << "loaded SVM vocabulary of size=" << _fids.size() << std::endl;
+    _logger->info("loaded SVM vocabulary of size={}",_fids.size());
   }
   
 }

--- a/src/svminputfileconn.h
+++ b/src/svminputfileconn.h
@@ -46,6 +46,7 @@ namespace dd
     
     SVMInputFileConn *_cifc = nullptr;
     APIData _adconf;
+    std::shared_ptr<spdlog::logger> _logger;
   };
   
   class SVMline
@@ -142,7 +143,7 @@ namespace dd
 	      DataEl<DDSvm> ddsvm;
 	      ddsvm._ctype._cifc = this;
 	      ddsvm._ctype._adconf = ad_input;
-	      ddsvm.read_element(_svm_fname);
+	      ddsvm.read_element(_svm_fname,this->_logger);
 	    }
 	  else // training from posted data (in-memory)
 	    {
@@ -151,7 +152,7 @@ namespace dd
 		  DataEl<DDSvm> ddsvm;
 		  ddsvm._ctype._cifc = this;
 		  ddsvm._ctype._adconf = ad_input;
-		  ddsvm.read_element(_uris.at(i));
+		  ddsvm.read_element(_uris.at(i),this->_logger);
 		}
 	      /*if (_scale)
 		{
@@ -177,7 +178,7 @@ namespace dd
 	      DataEl<DDSvm> ddsvm;
 	      ddsvm._ctype._cifc = this;
 	      ddsvm._ctype._adconf = ad_input;
-	      ddsvm.read_element(_uris.at(i));
+	      ddsvm.read_element(_uris.at(i),this->_logger);
 	    }
 	}
       if (_db_fname.empty() && _svmdata.empty())

--- a/src/tfinputconns.h
+++ b/src/tfinputconns.h
@@ -36,9 +36,8 @@
 
 #include "inputconnectorstrategy.h"
 #include "ext/base64/base64.h"
-#include <glog/logging.h>
 
- namespace dd
+namespace dd
  {
   class TFInputInterface
   {

--- a/src/tflib.cc
+++ b/src/tflib.cc
@@ -94,7 +94,7 @@ namespace dd
       throw MLLibBadParamException("number of classes is unknown (nclasses == 0)");
     if (_regression && _ntargets == 0)
       throw MLLibBadParamException("number of regression targets is unknown (ntargets == 0)");
-    this->_mlmodel.read_from_repository(this->_mlmodel._repo);
+    this->_mlmodel.read_from_repository(this->_mlmodel._repo,this->_logger);
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
@@ -177,13 +177,13 @@ namespace dd
     std::string graphFile = this->_mlmodel._graphName;
     if (graphFile.empty())
       throw MLLibBadParamException("No pre-trained model found in model repository");
-    LOG(INFO) << "test: using graphFile dir=" << graphFile;
+    this->_logger->info("test: using graphFile dir={}",graphFile);
     // Loading the graph to the given variable
     tensorflow::Status graphLoadedStatus = ReadBinaryProto(tensorflow::Env::Default(),graphFile,&graph_def);
     
     if (!graphLoadedStatus.ok())
       {
-	LOG(ERROR) << "failed loading tensorflow graph with status=" << graphLoadedStatus.ToString() << std::endl;
+	this->_logger->error("failed loading tensorflow graph with status={}",graphLoadedStatus.ToString());
 	throw MLLibBadParamException("failed loading tensorflow graph with status=" + graphLoadedStatus.ToString());
       }
     std::string inputLayer = _inputLayer;
@@ -191,12 +191,12 @@ namespace dd
     if (inputLayer.empty())
       {
 	inputLayer = graph_def.node(0).name();
-	LOG(INFO) << "testing: using input layer=" << inputLayer << std::endl;
+	this->_logger->info("testing: using input layer={}",inputLayer);
       }
     if (outputLayer.empty())
       {
 	outputLayer = graph_def.node(graph_def.node_size()-1).name();
-	LOG(INFO) << "testing: using output layer=" << outputLayer << std::endl;
+	this->_logger->info("testing: using output layer={}",outputLayer);
       }
     
     // creating a session with the graph
@@ -316,13 +316,13 @@ namespace dd
 	std::string graphFile = this->_mlmodel._graphName;
 	if (graphFile.empty())
 	  throw MLLibBadParamException("No pre-trained model found in model repository");
-	LOG(INFO) << "predict: using graphFile dir=" << graphFile;
+	this->_logger->info("predict: using graphFile dir={}",graphFile);
 	// Loading the graph to the given variable
 	tensorflow::Status graphLoadedStatus = ReadBinaryProto(tensorflow::Env::Default(),graphFile,&graph_def);
 	
 	if (!graphLoadedStatus.ok())
 	  {
-	    LOG(ERROR) << "failed loading tensorflow graph with status=" << graphLoadedStatus.ToString() << std::endl;
+	    this->_logger->error("failed loading tensorflow graph with status={}",graphLoadedStatus.ToString());
 	    throw MLLibBadParamException("failed loading tensorflow graph with status=" + graphLoadedStatus.ToString());
 	  }
 
@@ -334,12 +334,12 @@ namespace dd
 	if (_inputLayer.empty())
 	  {
 	    _inputLayer = graph_def.node(0).name();
-	    LOG(INFO) << "using input layer=" << _inputLayer << std::endl;
+	    this->_logger->info("using input layer={}",_inputLayer);
 	  }
 	if (_outputLayer.empty())
 	  {
 	    _outputLayer = graph_def.node(graph_def.node_size()-1).name();
-	    LOG(INFO) << "using output layer=" << _outputLayer << std::endl;
+	    this->_logger->info("using output layer={}",_outputLayer);
 	  }
 	//tensorflow::graph::SetDefaultDevice(device, &graph_def);
 	

--- a/src/tfmodel.cc
+++ b/src/tfmodel.cc
@@ -29,13 +29,14 @@ namespace dd
   {
    if (ad.has("repository"))
       {
-	read_from_repository(ad.get("repository").get<std::string>()); // XXX: beware, error not caught
+	read_from_repository(ad.get("repository").get<std::string>(),spdlog::get("api")); // XXX: beware, error not caught
 	this-> _modelRepo = ad.get("repository").get<std::string>();
       }
-   read_corresp_file();
+   read_corresp_file(spdlog::get("api"));
   }
 
-  int TFModel::read_from_repository(const std::string &repo)
+  int TFModel::read_from_repository(const std::string &repo,
+				    const std::shared_ptr<spdlog::logger> &logger)
   {
     std::string graphName = ".pb";
     std::string labelFile = ".txt";
@@ -44,7 +45,7 @@ namespace dd
   	int e = fileops::list_directory(repo,true,false,lfiles);
     if (e != 0)
       {
-	LOG(ERROR) << "error reading or listing caffe models in repository " << repo << std::endl;
+	logger->error("error reading or listing caffe models in repository {}",repo);
 	return 1;
       }
       
@@ -74,13 +75,13 @@ namespace dd
 	return 0;
   }
 
-  int TFModel::read_corresp_file()
+  int TFModel::read_corresp_file(const std::shared_ptr<spdlog::logger> &logger)
   {
     if (!_corresp.empty())
       {
 	std::ifstream ff(_corresp);
 	if (!ff.is_open())
-	  LOG(ERROR) << "cannot open TF model corresp file=" << _corresp << std::endl;
+	  logger->error("cannot open TF model corresp file={}",_corresp);
 	else{
 	  std::string line;
 	  while(!ff.eof())

--- a/src/tfmodel.cc
+++ b/src/tfmodel.cc
@@ -21,7 +21,6 @@
 
 #include "tfmodel.h"
 #include <utils/fileops.hpp>
-#include <glog/logging.h>
 #include <string>
 namespace dd
 {

--- a/src/tfmodel.h
+++ b/src/tfmodel.h
@@ -24,7 +24,9 @@
 
 #include "mlmodel.h"
 #include "apidata.h"
+#include <spdlog/spdlog.h>
 #include <string>
+
 namespace dd
 {
   class TFModel : public MLModel
@@ -36,9 +38,10 @@ namespace dd
       :MLModel(repo) {}
     ~TFModel() {}
     
-    int read_from_repository(const std:: string &repo);
+    int read_from_repository(const std:: string &repo,
+			     const std::shared_ptr<spdlog::logger> &logger);
 
-    int read_corresp_file();
+    int read_corresp_file(const std::shared_ptr<spdlog::logger> &logger);
 
     inline std::string get_hcorresp(const int &i)
     {

--- a/src/tsnelib.cc
+++ b/src/tsnelib.cc
@@ -23,7 +23,6 @@
 #include "csvinputfileconn.h"
 #include "outputconnectorstrategy.h"
 #include <thread>
-#include <glog/logging.h>
 
 namespace dd
 {
@@ -42,7 +41,6 @@ namespace dd
     unsigned int cores = std::thread::hardware_concurrency();
     if (!cores)
       cores = my_hardware_concurrency();
-    LOG(INFO) << "Detected " << cores << " cores";
     return cores;
   }
   
@@ -112,6 +110,7 @@ namespace dd
 	D = inputc._D;
 	std::cerr << "N=" << N << " / D=" << D << std::endl;
 	int num_threads = hardware_concurrency();
+	this->_logger->info("Detected {} cores", num_threads);
 	Y = new double[N*_no_dims]; // results
 	for (int i=0;i<N*_no_dims;i++)
 	  Y[i] = 0.0;
@@ -119,7 +118,7 @@ namespace dd
 	TSNE tsne = TSNE(N,D,_perplexity,_theta);
 	tsne.step1(inputc._X.data(),Y,num_threads);
 	int test_iter = 50;
-	time_t start = time(0);
+	//time_t start = time(0);
 	double loss = 0.0;
 	for (int iter = 0; iter < _iterations; iter++) {
 	  tsne.step2_one_iter(Y,iter,loss,test_iter);
@@ -129,7 +128,7 @@ namespace dd
       }
     catch(std::exception &e)
       {
-	LOG(ERROR) << e.what();
+	this->_logger->error(e.what());
 	throw; //TODO: MLLib exception
       }
 

--- a/src/txtinputfileconn.cc
+++ b/src/txtinputfileconn.cc
@@ -383,7 +383,7 @@ namespace dd
 	int pos = std::atoi(tokens.at(1).c_str());
 	_vocab.emplace(std::make_pair(key,Word(pos)));
       }
-    std::cerr << "loaded vocabulary of size=" << _vocab.size() << std::endl;
+    _logger->info("loaded vocabulary of size={}",_vocab.size());
   }
 
   void TxtInputFileConn::build_alphabet()

--- a/src/txtinputfileconn.cc
+++ b/src/txtinputfileconn.cc
@@ -23,7 +23,6 @@
 #include "utils/fileops.hpp"
 #include "utils/utils.hpp"
 #include <boost/tokenizer.hpp>
-#include <glog/logging.h>
 #include <iostream>
 
 namespace dd
@@ -39,7 +38,7 @@ namespace dd
     std::ifstream txt_file(fname);
     if (!txt_file.is_open())
       {
-	LOG(ERROR) << "cannot open file=" << fname;
+	_logger->error("cannot open file={}",fname);
 	throw InputConnectorBadParamException("cannot open file " + fname);
       }
     std::stringstream buffer;
@@ -71,7 +70,7 @@ namespace dd
     std::unordered_set<std::string> subdirs;
     if (fileops::list_directory(dir,false,true,subdirs))
       throw InputConnectorBadParamException("failed reading text subdirectories in data directory " + dir);
-    LOG(INFO) << "txtinputfileconn: list subdirs size=" << subdirs.size();
+    _logger->info("txtinputfileconn: list subdirs size={}",subdirs.size());
     
     // list files and classes
     bool test_dir = false;
@@ -88,7 +87,7 @@ namespace dd
 	    if (!correspf.is_open())
 	      {
 		std::string err_msg = "Failed opening corresp file before reading txt test data directory";;
-		LOG(ERROR) << err_msg;
+		_logger->error(err_msg);
 		throw InputConnectorInternalException(err_msg);
 	      }
 	    std::string line;
@@ -119,7 +118,7 @@ namespace dd
 		std::unordered_map<std::string,int>::const_iterator hcit;
 		if ((hcit=hcorresp_r.find(cls))==hcorresp_r.end())
 		  {
-		    LOG(ERROR) << "class " << cls << " appears in testing set but not in training set, skipping";
+		    _logger->error("class {} appears in testing set but not in training set, skipping",cls);
 		    ++uit;
 		    continue;
 		  }
@@ -228,8 +227,8 @@ namespace dd
 	correspf.close();
       }    
 
-    LOG(INFO) << "vocabulary size=" << _ctfc->_vocab.size() << std::endl;
-        
+    _logger->info("vocabulary size={}",_ctfc->_vocab.size());
+    
     return 0;
   }
   
@@ -315,7 +314,7 @@ namespace dd
 		    }
 		  catch(...)
 		    {
-		      LOG(ERROR) << "Invalid UTF-8 character in " << w << std::endl;
+		      _logger->error("Invalid UTF-8 character in {}",w);
 		      c = 0;
 		      ++str_i;
 		    }

--- a/src/txtinputfileconn.h
+++ b/src/txtinputfileconn.h
@@ -44,6 +44,7 @@ namespace dd
     int read_dir(const std::string &dir);
 
     TxtInputFileConn *_ctfc = nullptr;
+    std::shared_ptr<spdlog::logger> _logger;
   };
 
   class Word
@@ -263,7 +264,7 @@ namespace dd
 	{
 	  DataEl<DDTxt> dtxt;
 	  dtxt._ctype._ctfc = this;
-	  if (dtxt.read_element(u) || (_txt.empty() && _db_fname.empty()))
+	  if (dtxt.read_element(u,this->_logger) || (_txt.empty() && _db_fname.empty()))
 	    {
 	      throw InputConnectorBadParamException("no data for text in " + u);
 	    }

--- a/src/unsupervisedoutputconnector.h
+++ b/src/unsupervisedoutputconnector.h
@@ -129,6 +129,9 @@ namespace dd
 
     void finalize(const APIData &ad_in, APIData &ad_out, MLModel *mlm)
     {
+#ifndef USE_SIMSEARCH
+      (void)mlm;
+#endif
       if (ad_in.has("binarized"))
 	_binarized = ad_in.get("binarized").get<bool>();
       else if (ad_in.has("bool_binarized"))
@@ -212,6 +215,9 @@ namespace dd
 
     void to_ad(APIData &out, const std::unordered_set<std::string> &indexed_uris) const
     {
+#ifndef USE_SIMSEARCH
+      (void)indexed_uris;
+#endif
       std::unordered_set<std::string>::const_iterator hit;
       std::vector<APIData> vpred;
       for (size_t i=0;i<_vvres.size();i++)

--- a/src/xgbinputconns.cc
+++ b/src/xgbinputconns.cc
@@ -182,10 +182,10 @@ namespace dd
 	//- shuffle & split matrix as required (read parameters -> fillup_parameters or init ?)
 	APIData ad_input = ad.getobj("parameters").getobj("input");
 	fillup_parameters(ad_input);
-	LOG(INFO) << "loading " << _uris.at(0);
+	_logger->info("loading {}",uris.at(0));
 	_m = std::shared_ptr<xgboost::DMatrix>(xgboost::DMatrix::Load(_uris.at(0),silent,dsplit));
 	size_t rsize = _m->info().num_row;
-	LOG(INFO) << "successfully read " << rsize << " rows";
+	_logger->info("successfully read {} rows",rsize);
 
 	std::vector<int> rindex(rsize);
 	std::iota(std::begin(rindex),std::end(rindex),0);
@@ -204,7 +204,7 @@ namespace dd
 	if (_test_split > 0.0)
 	  {
 	    // XXX: not optimal memory-wise, due to the XGDMatrixSlice op
-	    LOG(INFO) << "splitting dataset";
+	    _logger->info("splitting dataset");
 	    int split_size = std::floor(rsize * (1.0-_test_split));
 	    std::vector<int> train_rindex(rindex.begin(),rindex.begin()+split_size);
 	    std::vector<int> test_rindex(rindex.begin()+split_size,rindex.end());
@@ -212,7 +212,7 @@ namespace dd
 	    xgboost::DMatrix *mtrain = XGDMatrixSliceDMatrix(_m.get(),&train_rindex[0],train_rindex.size());
 	    _mtest = std::shared_ptr<xgboost::DMatrix>(XGDMatrixSliceDMatrix(_m.get(),&test_rindex[0],test_rindex.size()));
 	    _m = std::shared_ptr<xgboost::DMatrix>(mtrain);
-	    LOG(INFO) << "dataset sucessfully splitted";
+	    _logger->info("dataset successfully splitted");
 	  }
 	else
 	  {
@@ -227,10 +227,10 @@ namespace dd
       }
     else if (_uris.size() == 2) // with test file
       {
-	LOG(INFO) << "reading train and test matrices";
+	_logger->info("reading train and test matrices");
 	_m = std::shared_ptr<xgboost::DMatrix>(xgboost::DMatrix::Load(_uris.at(0),silent,dsplit));
 	_mtest = std::shared_ptr<xgboost::DMatrix>(xgboost::DMatrix::Load(_uris.at(1),silent,dsplit));
-	LOG(INFO) << "Successfully acquired data";
+	_logger->info("successfully acquired data");
       }
   }
 

--- a/src/xgblib.cc
+++ b/src/xgblib.cc
@@ -284,7 +284,7 @@ namespace dd
 	  std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(_params.model_in.c_str(), "r")); //TODO: update the model path (repo)
 	  learner->Load(fi.get());
 	} else {
-	  LOG(INFO) << "initializing model";
+	  this->_logger->info("initializing model");
 	  learner->InitModel();
 	}
       }    
@@ -296,7 +296,7 @@ namespace dd
 	this->add_meas("iteration",i);
 	if (version % 2 == 0) {
 	  if (_params.silent == 0) {
-	    LOG(INFO) << "boosting round " << i;
+	    this->_logger->info("boosting round {}",i);
 	  }
 	  learner->UpdateOneIter(i, dtrain.get());
 	  if (learner->AllowLazyCheckPoint()) {
@@ -306,22 +306,7 @@ namespace dd
 	  }
 	  version += 1;
 	}
-	//std::cerr << "version=" << version << " / rabit version=" << rabit::VersionNumber() << std::endl;
-	//CHECK_EQ(version, rabit::VersionNumber());
-	/*std::string res = learner->EvalOneIter(i, eval_datasets, eval_data_names);
-	  if (rabit::IsDistributed()) {
-	  if (rabit::GetRank() == 0) {
-	  //LOG(TRACKER) << res;
-	  LOG(INFO) << "res=" << res << std::endl;
-	  }
-	  } else {
-	  std::cerr << "param silent=" << _params.silent << std::endl;
-	if (_params.silent < 2) {
-	//LOG(CONSOLE) << res;
-	LOG(INFO) << "res=" << res << std::endl;
-	}
-	}*/
-
+	
 	// measures for dd
 	if (i > 0 && i % test_interval == 0 && !eval_datasets.empty())
 	  {
@@ -334,7 +319,7 @@ namespace dd
 		if (m != "cmdiag" && m != "cmfull" && m != "labels") // do not report confusion matrix in server logs
 		  {
 		    double mval = meas_obj.get(m).get<double>();
-		    LOG(INFO) << m << "=" << mval;
+		    this->_logger->info("{}={}",m,mval);
 		    this->add_meas(m,mval);
 		    if (!std::isnan(mval)) // if testing occurs once before training even starts, loss is unknown and we don't add it to history.
 		      this->add_meas_per_iter(m,mval);
@@ -345,13 +330,13 @@ namespace dd
 		    std::string mdiag_str;
 		    for (size_t i=0;i<mdiag.size();i++)
 		      mdiag_str += std::to_string(i) + ":" + std::to_string(mdiag.at(i)) + " ";
-		    LOG(INFO) << m << "=[" << mdiag_str << "]";
+		    this->_logger->info("{}=[{}]",m,mdiag_str);
 		  }
 	      }
 	  }
 	
 	if (_params.save_period != 0 && (i + 1) % _params.save_period == 0) {
-	  LOG(INFO) << "model saving / repo=" << this->_mlmodel._repo << std::endl;;
+	  this->_logger->info("model saving / repo={}",this->_mlmodel._repo);
 	  std::ostringstream os;
 	  os << this->_mlmodel._repo << '/'
 	     << std::setfill('0') << std::setw(4)
@@ -427,7 +412,7 @@ namespace dd
       {
 	_learner = xgboost::Learner::Create({});
 	std::string model_in = this->_mlmodel._weights;
-        LOG(INFO) << "loading XGBoost model file=" << model_in;
+	this->_logger->info("loading XGBoost model file={}",model_in);
 	std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(model_in.c_str(),"r"));
 	_learner->Load(fi.get());
 	// we can't read the objective function string name from the xgboost in-memory model,

--- a/src/xgblib.cc
+++ b/src/xgblib.cc
@@ -73,7 +73,7 @@ namespace dd
       throw MLLibBadParamException("number of classes is unknown (nclasses == 0)");
     if (_regression && _ntargets == 0)
       throw MLLibBadParamException("number of regression targets is unknown (ntargets == 0)");
-    this->_mlmodel.read_from_repository();
+    this->_mlmodel.read_from_repository(this->_logger);
   }
 
   template <class TInputConnectorStrategy, class TOutputConnectorStrategy, class TMLModel>
@@ -89,7 +89,7 @@ namespace dd
 									       APIData &out)
   {
     // any check on model here
-    this->_mlmodel.read_from_repository();
+    this->_mlmodel.read_from_repository(this->_logger);
     
     // mutex if train and predict calls need to be isolated
     std::lock_guard<std::mutex> lock(_learner_mutex);
@@ -379,7 +379,7 @@ namespace dd
       test(ad,learner,inputc._mtest.get(),out);
       
       // prepare model
-      this->_mlmodel.read_from_repository();
+      this->_mlmodel.read_from_repository(this->_logger);
       this->_mlmodel.read_corresp_file();
       
       // add whatever the input connector needs to transmit out
@@ -417,7 +417,7 @@ namespace dd
 	_learner->Load(fi.get());
 	// we can't read the objective function string name from the xgboost in-memory model,
 	// so let's read it from file
-	_objective = this->_mlmodel.lookup_objective(model_in);
+	_objective = this->_mlmodel.lookup_objective(model_in,this->_logger);
 	if (_objective == "")
 	  throw MLLibInternalException("failed to read the objective from XGBoost model file " + model_in);
       }

--- a/src/xgbmodel.cc
+++ b/src/xgbmodel.cc
@@ -31,7 +31,7 @@ namespace dd
   {
     if (ad.has("repository"))
       this->_repo = ad.get("repository").get<std::string>();
-    read_from_repository();
+    read_from_repository(spdlog::get("api"));
     read_corresp_file();
   }
 
@@ -80,7 +80,7 @@ namespace dd
     std::ifstream ff(modelfile);
     if (!ff.is_open())
       {
-	this->_logger("cannot open xgb model file {} for looking objective up",modelfile);
+	logger("cannot open xgb model file {} for looking objective up",modelfile);
 	return "";
       }
     std::string line;

--- a/src/xgbmodel.cc
+++ b/src/xgbmodel.cc
@@ -35,7 +35,7 @@ namespace dd
     read_corresp_file();
   }
 
-  int XGBModel::read_from_repository()
+  int XGBModel::read_from_repository(const std::shared_ptr<spdlog::logger> &logger)
   {
     static std::string weights = ".model";
     static std::string corresp = "corresp";
@@ -43,7 +43,7 @@ namespace dd
     int e = fileops::list_directory(_repo,true,false,lfiles);
     if (e != 0)
       {
-	this->_logger->error("error reading or listing XGBoost models in repository {}",_repo);
+	logger->error("error reading or listing XGBoost models in repository {}",_repo);
 	return 1;
       }
     std::string weightsf,correspf;
@@ -70,7 +70,8 @@ namespace dd
     return 0;
   }
 
-  std::string XGBModel::lookup_objective(const std::string &modelfile)
+  std::string XGBModel::lookup_objective(const std::string &modelfile,
+					 const std::shared_ptr<spdlog::logger> &logger)
   {
     static std::string objective_softprob = "multi:softprob";
     static std::string objective_binary = "binary:logistic";

--- a/src/xgbmodel.cc
+++ b/src/xgbmodel.cc
@@ -80,7 +80,7 @@ namespace dd
     std::ifstream ff(modelfile);
     if (!ff.is_open())
       {
-	logger("cannot open xgb model file {} for looking objective up",modelfile);
+	logger->info("cannot open xgb model file {} for looking objective up",modelfile);
 	return "";
       }
     std::string line;

--- a/src/xgbmodel.cc
+++ b/src/xgbmodel.cc
@@ -43,7 +43,7 @@ namespace dd
     int e = fileops::list_directory(_repo,true,false,lfiles);
     if (e != 0)
       {
-	LOG(ERROR) << "error reading or listing XGBoost models in repository " << _repo << std::endl;
+	this->_logger->error("error reading or listing XGBoost models in repository {}",_repo);
 	return 1;
       }
     std::string weightsf,correspf;
@@ -79,7 +79,7 @@ namespace dd
     std::ifstream ff(modelfile);
     if (!ff.is_open())
       {
-	LOG(ERROR) << "cannot open xgb model file " << modelfile << " for looking objective up";
+	this->_logger("cannot open xgb model file {} for looking objective up",modelfile);
 	return "";
       }
     std::string line;

--- a/src/xgbmodel.h
+++ b/src/xgbmodel.h
@@ -24,6 +24,7 @@
 
 #include "mlmodel.h"
 #include "apidata.h"
+#include <spdlog/spdlog.h>
 #include <string>
 #include <unordered_map>
 
@@ -38,9 +39,10 @@ namespace dd
       :MLModel(repo) {}
     ~XGBModel() {}
 
-    int read_from_repository();
+    int read_from_repository(const std::shared_ptr<spdlog::logger> &logger);
 
-    std::string lookup_objective(const std::string &modelfile);
+    std::string lookup_objective(const std::string &modelfile,
+				 const std::shared_ptr<spdlog::logger> &logger);
     
     //TODO
     std::string _weights; /**< file with model weights. */

--- a/tests/ut-caffeapi.cc
+++ b/tests/ut-caffeapi.cc
@@ -65,11 +65,10 @@ static std::string iterations_sflare = "2000";
 static std::string iterations_camvid = "2";
 #endif
 
-static std::string gpuid = "0"; // change as needed
+static std::string gpuid = "2"; // change as needed
 
 TEST(caffeapi,service_train)
 {
-::google::InitGoogleLogging("ut_caffeapi");
 // create service
   JsonAPI japi;
   std::string sname = "my_service";

--- a/tests/ut-httpapi.cc
+++ b/tests/ut-httpapi.cc
@@ -58,7 +58,6 @@ TEST(httpjsonapi,uri_query_to_json)
 
 TEST(httpjsonapi,info)
 {
-  ::google::InitGoogleLogging("ut_httpapi");
   HttpJsonAPI hja;
   hja.start_server_daemon(host,std::to_string(port),nthreads);
   std::string luri = "http://" + host + ":" + std::to_string(port);

--- a/tests/ut-xgbapi.cc
+++ b/tests/ut-xgbapi.cc
@@ -46,7 +46,6 @@ static std::string iterations_sflare = "100";
 
 TEST(xgbapi,service_train_csv)
 {
-::google::InitGoogleLogging("ut_xgbapi");
   JsonAPI japi;
   std::string sname = "my_service";
   std::string jstr = "{\"mllib\":\"xgboost\",\"description\":\"my classifier\",\"type\":\"supervised\",\"model\":{\"repository\":\"" +  forest_repo + "\"},\"parameters\":{\"input\":{\"connector\":\"csv\"},\"mllib\":{\"nclasses\":7}}}";


### PR DESCRIPTION
This PR allows to track each service separately from within the logs.

Notes:

- using spdlog for fast logging
- one logger per service
- a dedicated logger for the front API operations
- errors, warnings and info logging
- removed glog dependency