### PR TITLE
Multi label soft : debug + other version of distance correlation

### DIFF
--- a/src/caffeinputconns.cc
+++ b/src/caffeinputconns.cc
@@ -242,6 +242,11 @@ namespace dd
 								const std::string &encode_type) // 'png', 'jpg', ...
 {
   std::string testdbfullname = testdbname + "." + backend;
+  if (fileops::file_exists(testdbfullname))
+    {
+      LOG(WARNING) << "test db " << testdbfullname << " already exists, bypassing creation";
+      return;
+    }
   vector<std::pair<std::string, std::vector<float> > > lines;
     caffe::ReadImagesList(test_lst,&lines);
     std::vector<std::pair<std::string,int>> test_lfiles_1;

--- a/src/caffelib.cc
+++ b/src/caffelib.cc
@@ -1177,8 +1177,9 @@ namespace dd
 	    
 	    if (_regression && _ntargets > 1) // slicing is involved
 	      slot--; // labels appear to be last
-	    else if (inputc._multi_label)
-	      slot--;
+	    else if (inputc._multi_label && ( inputc._db || ! (typeid(inputc) == typeid(ImgCaffeInputFileConn))
+                                           ||  _nclasses <= 1))
+          slot--;
 	    int scount = lresults[slot]->count();
 	    int scperel = scount / dv_size;
 

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -786,7 +786,6 @@ namespace dd
                                       double &r_2,
                                       double *delta_scores, const double deltas[], const int ndeltas)
     {
-      // distance correlation seems hard to compute w/o using lots of mem
       int batch_size = ad.get("batch_size").get<int>();
       kl_divergence = 0;
       js_divergence = 0;
@@ -855,17 +854,18 @@ namespace dd
 
       distance_correlation = 0;
 
+
+
+      double t_jk[nclasses][nclasses];
+      double p_jk[nclasses][nclasses];
+      double t_j[nclasses];
+      double t_k[nclasses];
+      double p_j[nclasses];
+      double p_k[nclasses];
+      double t_;
+      double p_;
+
       for (int i =0; i< batch_size; ++i) {
-
-        double t_jk[nclasses][nclasses];
-        double p_jk[nclasses][nclasses];
-        double t_j[nclasses];
-        double t_k[nclasses];
-        double p_j[nclasses];
-        double p_k[nclasses];
-        double t_;
-        double p_;
-
         APIData badj = ad.getobj(std::to_string(i));
         std::vector<double> targets = badj.get("target").get<std::vector<double>>();
         std::vector<double> predictions = badj.get("pred").get<std::vector<double>>();
@@ -874,7 +874,7 @@ namespace dd
         for (int j=0;j<nclasses;j++)
           for (int k=0; k<nclasses; ++k)
             {
-              if (targets[j] < 0 || targetsj[k] < 0)
+              if (targets[j] < 0 || targets[k] < 0)
                 continue;
               p_jk[j][k] = sqrt((predictions[j]-predictions[k]) * (predictions[j] -predictions[k])) ;
               t_jk[j][k] = sqrt((targets[j]-targets[k]) * (targets[j] -targets[k])) ;;

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -479,15 +479,26 @@ namespace dd
 	  bool bmcc = (std::find(measures.begin(),measures.end(),"mcc")!=measures.end());
 	  bool baccv = false;
 	  bool mlacc = false;
-      bool mlsoft = false;
+      bool mlsoft_kl = false;
+      bool mlsoft_js = false;
+      bool mlsoft_was = false;
+      bool mlsoft_ks = false;
+      bool mlsoft_dc = false;
+      bool mlsoft_r2 = false;
+      bool mlsoft_deltas = false;
        if (segmentation)
 	    baccv = (std::find(measures.begin(),measures.end(),"acc")!=measures.end());
 	  if (multilabel && !regression)
 	    mlacc = (std::find(measures.begin(),measures.end(),"acc")!=measures.end());
-
       if (multilabel && regression)
         {
-          mlsoft = (std::find(measures.begin(),measures.end(),"acc")!=measures.end());
+          mlsoft_kl = (std::find(measures.begin(),measures.end(),"kl")!=measures.end());
+          mlsoft_js = (std::find(measures.begin(),measures.end(),"js")!=measures.end());
+          mlsoft_was = (std::find(measures.begin(),measures.end(),"was")!=measures.end());
+          mlsoft_ks = (std::find(measures.begin(),measures.end(),"ks")!=measures.end());
+          mlsoft_dc = (std::find(measures.begin(),measures.end(),"dc")!=measures.end());
+          mlsoft_r2 = (std::find(measures.begin(),measures.end(),"r2")!=measures.end());
+          mlsoft_deltas = (std::find(measures.begin(),measures.end(),"deltas")!=measures.end());
         }
 	  if (bauc) // XXX: applies two binary classification problems only
 	    {
@@ -524,32 +535,49 @@ namespace dd
 	      meas_out.add("specificity",specificity);
 	      meas_out.add("harmmean",harmmean);
 	    }
-      if (mlsoft)
+      if (mlsoft_kl)
         {
-          // below measures for soft multilabel
-          double kl_divergence = 0; // kl: amount of lost info if using pred instead of truth
-          double js_divergence = 0 ; // jsd: symetrized version of kl
-          double wasserstein = 0; // wasserstein distance
-          double kolmogorov_smirnov = 0; // kolmogorov-smirnov test aka max individual error
-          double distance_correlation = 0; // distance correlation , same as brownian correlation
-          double r_2 = 0; // r_2 score: best  is 1, min is 0
+          double kl_divergence = multilabel_soft_kl(ad_res); // kl: amount of lost info if using pred instead of truth
+          meas_out.add("kl_divergence",kl_divergence);
+        }
+      if (mlsoft_js)
+        {
+          double js_divergence = multilabel_soft_js(ad_res) ; // jsd: symetrized version of kl
+	      meas_out.add("js_divergence",js_divergence);
+        }
+      if (mlsoft_was)
+        {
+          double wasserstein = multilabel_soft_was(ad_res); // wasserstein distance
+	      meas_out.add("wasserstein",wasserstein);
+        }
+      if (mlsoft_ks)
+        {
+          double kolmogorov_smirnov = multilabel_soft_ks(ad_res); // kolmogorov-smirnov test aka max individual error
+	      meas_out.add("kolmogorov_smirnov",kolmogorov_smirnov);
+        }
+      if (mlsoft_dc)
+        {
+          double distance_correlation = multilabel_soft_dc(ad_res); // distance correlation , same as brownian correlation
+	      meas_out.add("distance_correlation",distance_correlation);
+        }
+      if (mlsoft_r2)
+        {
+          double r_2 = multilabel_soft_r2(ad_res); // r_2 score: best  is 1, min is 0
+          meas_out.add("r2",r_2);
+        }
+      if (mlsoft_deltas)
+        {
           std::vector<double> delta_scores {0,0,0,0}; // delta-score , aka 1 if pred \in [truth-delta, truth+delta]
           std::vector<double> deltas {0.05, 0.1, 0.2, 0.5};
-          multilabel_acc_soft(ad_res, kl_divergence, js_divergence, wasserstein, kolmogorov_smirnov,
-                               distance_correlation, r_2, delta_scores, deltas, 4);
-          meas_out.add("kl_divergence",kl_divergence);
-	      meas_out.add("js_divergence",js_divergence);
-	      meas_out.add("wasserstein",wasserstein);
-	      meas_out.add("kolmogorov_smirnov",kolmogorov_smirnov);
-	      meas_out.add("distance_correlation",distance_correlation);
-          meas_out.add("r2",r_2);
-          for (int i=0; i<4; ++i)
+          multilabel_soft_deltas(ad_res, delta_scores, deltas);
+          for (int i=0; i<deltas.size(); ++i)
             {
               std::ostringstream sstr;
               sstr << "delta_score_" << deltas[i];
               meas_out.add(sstr.str(),delta_scores[i]);
             }
         }
+
 	  if (!multilabel && !segmentation && bf1)
 	    {
 	      double f1,precision,recall,acc;
@@ -780,21 +808,11 @@ namespace dd
       return f1;
     }
 
-    static double multilabel_acc_soft(const APIData &ad, double &kl_divergence, double  &js_divergence,
-                                      double &wasserstein,
-                                      double &kolmogorov_smirnov,double &distance_correlation,
-                                      double &r_2,
-                                      std::vector<double>& delta_scores, const std::vector<double>& deltas, const int ndeltas)
+    static double multilabel_soft_kl(const APIData &ad)
     {
-      int batch_size = ad.get("batch_size").get<int>();
-      kl_divergence = 0;
-      js_divergence = 0;
-      wasserstein = 0;
-      kolmogorov_smirnov = 0;
+      double kl_divergence = 0;
       long int total_number = 0;
-      double tmean = 0;
-      for (int k =0; k<ndeltas; ++k)
-        delta_scores[k] = 0;
+      int batch_size = ad.get("batch_size").get<int>();
       for (int i=0;i<batch_size;i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
@@ -803,40 +821,22 @@ namespace dd
           for (size_t j=0;j<predictions.size();j++)
             {
               if (targets[j] < 0) // case ignore_label
-                 continue;
+                continue;
               total_number++;
-              // d_kl(target||pred) = sum target * log (target/pred)
-              // do not work if zeros, give a threshold
               double eps = 0.00001;
               double tval = (targets[j]< eps)? eps: targets[j];
               double pval = (predictions[j]< eps)? eps: predictions[j];
               kl_divergence += tval * log (tval/pval);
-              js_divergence += 0.5 * (tval * log(2*tval/(tval+pval))) + 0.5 * (pval * log(2*pval/(tval+pval)));
-              double dif = targets[j] - predictions[j];
-              wasserstein += dif*dif;
-              dif = fabs(dif);
-              if (dif > kolmogorov_smirnov)
-                kolmogorov_smirnov = dif;
-              for (int k=0; k<ndeltas; ++k)
-                  if (dif < deltas[k])
-                    delta_scores[k]++;
-              tmean += targets[j];
             }
         }
+      return kl_divergence / (double)total_number;
+    }
 
-
-      double ssres = wasserstein;
-      wasserstein = sqrt(wasserstein);
-      // below normalize to compare different learnings
-      kl_divergence /= (double)total_number;
-      js_divergence /= (double)total_number;
-      wasserstein /=  sqrt((double)total_number); // gives distance between 0 and 1
-      for (int k =0; k<ndeltas; ++k)
-        delta_scores[k] /=  (double)total_number; // gives proportion of good in 0:1 at every threshold
-      tmean /= (double)total_number;
-
-      double sstot = 0;
-
+    static double multilabel_soft_js(const APIData &ad)
+    {
+      int batch_size = ad.get("batch_size").get<int>();
+      double js_divergence = 0;
+      long int total_number = 0;
       for (int i=0;i<batch_size;i++)
         {
           APIData bad = ad.getobj(std::to_string(i));
@@ -844,21 +844,71 @@ namespace dd
           std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
           for (size_t j=0;j<predictions.size();j++)
             {
-              if (targets[j] < 0)
+              if (targets[j] < 0) // case ignore_label
                 continue;
-              sstot += (targets[j] - tmean) *  (targets[j] - tmean);
+              total_number++;
+              double eps = 0.00001;
+              double tval = (targets[j]< eps)? eps: targets[j];
+              double pval = (predictions[j]< eps)? eps: predictions[j];
+              js_divergence += 0.5 * (tval * log(2*tval/(tval+pval))) + 0.5 * (pval * log(2*pval/(tval+pval)));
             }
         }
-      r_2 = 1.0 - ssres/sstot;
+      return js_divergence / (double)total_number;
+    }
 
+    static double multilabel_soft_was(const APIData &ad)
+    {
+      int batch_size = ad.get("batch_size").get<int>();
+      double was = 0;
+      long int total_number = 0;
+      for (int i=0;i<batch_size;i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          for (size_t j=0;j<predictions.size();j++)
+            {
+              if (targets[j] < 0) // case ignore_label
+                continue;
+              total_number++;
+              double dif = targets[j] - predictions[j];
+              was += dif*dif;
+            }
+        }
+      was = sqrt(was);
+      return was/sqrt((double)total_number);
+    }
 
+    static double multilabel_soft_ks(const APIData &ad)
+    {
+      int batch_size = ad.get("batch_size").get<int>();
+      double ks = 0;
+      long int total_number = 0;
+      for (int i=0;i<batch_size;i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          for (size_t j=0;j<predictions.size();j++)
+            {
+              if (targets[j] < 0) // case ignore_label
+                continue;
+              total_number++;
+              double dif = targets[j] - predictions[j];
+              dif = fabs(dif);
+              if (dif > ks)
+                ks = dif;
+            }
+        }
+      return ks;
+    }
+
+    static double multilabel_soft_dc(const APIData &ad)
+    {
+      int batch_size = ad.get("batch_size").get<int>();
       int nclasses = ad.getobj(std::to_string(0)).get("target").get<std::vector<double>>().size();
 
-
-
-      distance_correlation = 0;
-
-
+      double distance_correlation = 0;
 
       double t_jk[nclasses][nclasses];
       double p_jk[nclasses][nclasses];
@@ -936,9 +986,75 @@ namespace dd
           distance_correlation += dcov / (sqrt(dvart * dvarp));
       }
       distance_correlation /= batch_size;
+      return distance_correlation;
+    }
 
+    static double multilabel_soft_r2(const APIData &ad)
+    {
+      int batch_size = ad.get("batch_size").get<int>();
+      double tmean = 0;
+      long int total_number = 0;
+      double ssres = 0;
+      for (int i=0;i<batch_size;i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          for (size_t j=0;j<predictions.size();j++)
+            {
+              if (targets[j] < 0) // case ignore_label
+                continue;
+              total_number++;
+              tmean += targets[j];
+              double dif = targets[j] - predictions[j];
+              ssres += dif*dif;
 
-      return r_2;
+            }
+        }
+      tmean /= (double)total_number;
+
+      double sstot = 0;
+
+      for (int i=0;i<batch_size;i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          for (size_t j=0;j<predictions.size();j++)
+            {
+              if (targets[j] < 0)
+                continue;
+              sstot += (targets[j] - tmean) *  (targets[j] - tmean);
+            }
+        }
+      return  1.0 - ssres/sstot;
+    }
+
+    static void multilabel_soft_deltas(const APIData &ad, std::vector<double>& delta_scores, const std::vector<double>& deltas)
+    {
+      int batch_size = ad.get("batch_size").get<int>();
+      long int total_number = 0;
+      for (int k =0; k<deltas.size(); ++k)
+        delta_scores[k] = 0;
+      for (int i=0;i<batch_size;i++)
+        {
+          APIData bad = ad.getobj(std::to_string(i));
+          std::vector<double> targets = bad.get("target").get<std::vector<double>>();
+          std::vector<double> predictions = bad.get("pred").get<std::vector<double>>();
+          for (size_t j=0;j<predictions.size();j++)
+            {
+              if (targets[j] < 0) // case ignore_label
+                continue;
+              total_number++;
+              double dif = fabs(targets[j] - predictions[j]);
+              for (int k=0; k<deltas.size(); ++k)
+                if (dif < deltas[k])
+                  delta_scores[k]++;
+            }
+        }
+      for (int k =0; k<deltas.size(); ++k)
+        delta_scores[k] /=  (double)total_number; // gives proportion of good in 0:1 at every threshold
+
     }
 
 

--- a/src/supervisedoutputconnector.h
+++ b/src/supervisedoutputconnector.h
@@ -933,9 +933,15 @@ namespace dd
           for (int k=0; k<nclasses; ++k)
             {
               if (targets[j] < 0 || targets[k] < 0)
-                continue;
-              p_jk[j][k] = sqrt((predictions[j]-predictions[k]) * (predictions[j] -predictions[k])) ;
-              t_jk[j][k] = sqrt((targets[j]-targets[k]) * (targets[j] -targets[k])) ;;
+                {
+                  p_jk[j][k] = 0;
+                  t_jk[j][k] = 0;
+                }
+              else
+                {
+                  p_jk[j][k] = sqrt((predictions[j]-predictions[k]) * (predictions[j] -predictions[k])) ;
+                  t_jk[j][k] = sqrt((targets[j]-targets[k]) * (targets[j] -targets[k])) ;;
+                }
             }
 
         t_ = 0;
@@ -946,10 +952,10 @@ namespace dd
           p_j[l] = 0;
           p_k[l] = 0;
           for (int m =0; m<nclasses; ++m) {
-            t_j[m] += t_jk[l][m];
-            t_k[m] += t_jk[m][l];
-            p_j[m] += p_jk[l][m];
-            p_k[m] += p_jk[m][l];
+            t_j[l] += t_jk[l][m];
+            t_k[l] += t_jk[m][l];
+            p_j[l] += p_jk[l][m];
+            p_k[l] += p_jk[m][l];
           }
           t_j[l] /= (double)nclasses;
           t_ += t_j[l];
@@ -1034,7 +1040,7 @@ namespace dd
     {
       int batch_size = ad.get("batch_size").get<int>();
       long int total_number = 0;
-      for (int k =0; k<deltas.size(); ++k)
+      for (unsigned int k =0; k<deltas.size(); ++k)
         delta_scores[k] = 0;
       for (int i=0;i<batch_size;i++)
         {
@@ -1047,12 +1053,12 @@ namespace dd
                 continue;
               total_number++;
               double dif = fabs(targets[j] - predictions[j]);
-              for (int k=0; k<deltas.size(); ++k)
+              for (unsigned int k=0; k<deltas.size(); ++k)
                 if (dif < deltas[k])
                   delta_scores[k]++;
             }
         }
-      for (int k =0; k<deltas.size(); ++k)
+      for (unsigned int k =0; k<deltas.size(); ++k)
         delta_scores[k] /=  (double)total_number; // gives proportion of good in 0:1 at every threshold
 
     }

--- a/tests/ut-conn.cc
+++ b/tests/ut-conn.cc
@@ -54,7 +54,7 @@ TEST(outputconn,mlsoft)
   ASSERT_NEAR(0.0178739,js, 0.0001);
   ASSERT_NEAR(0.0866025,was, 0.0001);
   ASSERT_EQ(0.1,ks);
-  ASSERT_NEAR(0,dc,0.001);
+  ASSERT_NEAR(0.941,dc,0.001);
   // TODO : dc makes sense only if variations over batch
   ASSERT_NEAR(0.94444,r2,0.0001);
   ASSERT_EQ(0.25,delta_scores[0]);

--- a/tests/ut-conn.cc
+++ b/tests/ut-conn.cc
@@ -46,16 +46,20 @@ TEST(outputconn,mlsoft)
     }
   SupervisedOutput so;
   std::vector<std::string> measures = {"acc"};
-  double kl, js, was, ks, dc, r2;
+  double kl = so.multilabel_soft_kl(res_ad);
+  double js = so.multilabel_soft_js(res_ad);
+  double was = so.multilabel_soft_was(res_ad);
+  double ks = so.multilabel_soft_ks(res_ad);
+  double dc = so.multilabel_soft_dc(res_ad);
+  double r2 = so.multilabel_soft_r2(res_ad);;
   std::vector<double> delta_scores {0,0,0,0};
   std::vector<double> deltas {0.05, 0.1, 0.2, 0.5};
-  so.multilabel_acc_soft(res_ad,kl,js,was,ks,dc,r2,delta_scores, deltas, 4);
+  so.multilabel_soft_deltas(res_ad,delta_scores, deltas);
   ASSERT_NEAR(0.257584,kl, 0.0001); // val checked with def
   ASSERT_NEAR(0.0178739,js, 0.0001);
   ASSERT_NEAR(0.0866025,was, 0.0001);
   ASSERT_EQ(0.1,ks);
-  ASSERT_NEAR(0.941,dc,0.001);
-  // TODO : dc makes sense only if variations over batch
+  ASSERT_NEAR(0.998,dc,0.001);
   ASSERT_NEAR(0.94444,r2,0.0001);
   ASSERT_EQ(0.25,delta_scores[0]);
   ASSERT_EQ(0.5,delta_scores[1]);

--- a/tests/ut-conn.cc
+++ b/tests/ut-conn.cc
@@ -47,8 +47,8 @@ TEST(outputconn,mlsoft)
   SupervisedOutput so;
   std::vector<std::string> measures = {"acc"};
   double kl, js, was, ks, dc, r2;
-  double delta_scores[4];
-  double deltas[4] = {0.05, 0.1, 0.2, 0.5};
+  std::vector<double> delta_scores {0,0,0,0};
+  std::vector<double> deltas {0.05, 0.1, 0.2, 0.5};
   so.multilabel_acc_soft(res_ad,kl,js,was,ks,dc,r2,delta_scores, deltas, 4);
   ASSERT_NEAR(0.257584,kl, 0.0001); // val checked with def
   ASSERT_NEAR(0.0178739,js, 0.0001);


### PR DESCRIPTION
in caffelib.cc: read the correct output layer
in supervised output connector : lighter distance correlation + eucll now discards -1 

for testing 
curl -X PUT "http://localhost:8080/services/test_multi" -d '{"model": {"templates": "../templates/caffe/", "repository": "/home/infantes/test/"}, "type": "supervised", "description": "imagenet classifier", "parameters": {"input": {"db": false, "height": 224, "connector": "image", "width": 224, "bw": false, "multi_label": true}, "mllib": {"finetuning": true, "rotate": false, "template": "resnet_50", "gpuid": [0], "db": false, "distort": {"all_effects": true, "prob": 0.01}, "noise": {"all_effects": true, "prob": 0.01}, "weights": "ResNet-50-model.caffemodel", "nclasses": 9, "mirror": true, "gpu": true, "regression": true}, "output": {}}, "mllib": "caffe"}'

for training:
curl -X PUT "http://localhost:8080/train" -d '{"async": true, "data": ["/home/infantes/test/part_shuf_train.txt", "/home/infantes/test/part_shuf_test.txt"], "parameters": {"input": {"db": false, "shuffle": true}, "mllib": {"gpu": true, "net": {"test_batch_size": 4, "batch_size": 16}, "solver": {"test_initialization": true, "base_lr": 0.001, "snapshot": 10000, "iterations": 300000, "test_interval": 100, "iter_size": 2, "solver_type": "SGD"}, "gpuid": [0], "resume": false}, "output": {"measure": ["acc", "eucll"]}}, "service": "test_multi"}'